### PR TITLE
fix: Authentication for system Flatpak installation (`polkit`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Feel free to join our community on [Discord](https://discord.gg/vZ7T2wJnsq) for 
 
 
 <p align="center">
-  <img src="https://github.com/TeamWheelWizard/.github/blob/main/images/dashboard.png" alt="Wheel Wizard Logo" width="450"/>
-  <img src="https://github.com/TeamWheelWizard/.github/blob/main/images/my_stuff.png" alt="Wheel Wizard Logo" width="450"/>
-  <img src="https://github.com/TeamWheelWizard/.github/blob/main/images/room_details.png" alt="Wheel Wizard Logo" width="450"/>
-  <img src="https://github.com/TeamWheelWizard/.github/blob/main/images/settings.png" alt="Wheel Wizard Logo" width="450"/>
+  <img src="https://github.com/TeamWheelWizard/.github/blob/main/images/screenshots/home_page.png" alt="Wheel Wizard Logo" width="450"/>
+  <img src="https://github.com/TeamWheelWizard/.github/blob/main/images/screenshots/rooms_page.png" alt="Wheel Wizard Logo" width="450"/>
+  <img src="https://github.com/TeamWheelWizard/.github/blob/main/images/screenshots/profile_page.png" alt="Wheel Wizard Logo" width="450"/>
+  <img src="https://github.com/TeamWheelWizard/.github/blob/main/images/screenshots/mods_browser.png" alt="Wheel Wizard Logo" width="450"/>
 </p>
 ---
 

--- a/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
+++ b/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
@@ -164,13 +164,13 @@ public static class LinuxDolphinInstaller
         }
 
         // Install Dolphin using Flatpak and report progress.
-        var exitCode = await RunProcessWithProgressAsync("flatpak", "install -y org.DolphinEmu.dolphin-emu", progress);
+        var exitCode = await RunProcessWithProgressAsync("pkexec", "flatpak --system install -y org.DolphinEmu.dolphin-emu", progress);
         if (exitCode is 127 or 126) //this is error unauthorized
         {
             Dispatcher.UIThread.InvokeAsync(() =>
             {
                 new MessageBoxWindow().SetTitleText("Error")
-                    .SetTitleText("You need to be an administrator to install Flatpak").Show();
+                    .SetTitleText("You need to be an administrator to install Dolphin via Flatpak").Show();
             });
             return false;
         }


### PR DESCRIPTION
- **Purpose of this PR:** Fix the issue where the system-wide Dolphin Flatpak installation fails without specifying why exactly (not the expected administrator pop-up)
- **How to Test:** On a default Arch Linux machine with the default `arch` user configuration (pre-built images), this behavior can be reproduced because with `flatpak` installed, the `arch` user does not have the privileges to perform a system-wide install without a prompt for the `root` password. The installation will fail without the usual "unauthorized" error, but a generic one, due to not using `pkexec`. If the `arch` user is added to the `wheel` group, however, the installation succeeds.
- **What Has Been Changed:** The invocation of the `flatpak install` command: it was changed to use `pkexec`, as well as the explicit `--system` flag because without that flag it might open another prompt to specify whether this should use a user or system repo.
- **Related Issue:** #43
- **Discussion Points:** It may be a good idea to have an option for the user to specify whether they want a `--system` or `--user` installation. This way, users without the `root` password or administrative privileges also get to install Dolphin for their own users.
