### PR TITLE
fix: Use sane path handling

### DIFF
--- a/WheelWizard/Services/Installation/AutoUpdater/AutoUpdaterLinux.cs
+++ b/WheelWizard/Services/Installation/AutoUpdater/AutoUpdaterLinux.cs
@@ -106,8 +106,12 @@ echo 'Update completed successfully.'
         {
             Process.Start(new ProcessStartInfo
             {
-                FileName = "chmod",
-                Arguments = $"+x \"{scriptFilePath}\"",
+                FileName = "/usr/bin/env",
+                ArgumentList = {
+                    "chmod",
+                    "+x",
+                    scriptFilePath,
+                },
                 CreateNoWindow = true,
                 UseShellExecute = false
             })?.WaitForExit();
@@ -123,8 +127,11 @@ echo 'Update completed successfully.'
 
         var processStartInfo = new ProcessStartInfo
         {
-            FileName = "bash",
-            Arguments = $"\"{scriptFilePath}\"",
+            FileName = "/usr/bin/env",
+            ArgumentList = {
+                "sh",
+                scriptFilePath,
+            },
             CreateNoWindow = false,
             UseShellExecute = false,
             WorkingDirectory = currentFolder

--- a/WheelWizard/Services/Installation/AutoUpdater/AutoUpdaterLinux.cs
+++ b/WheelWizard/Services/Installation/AutoUpdater/AutoUpdaterLinux.cs
@@ -110,6 +110,7 @@ echo 'Update completed successfully.'
                 ArgumentList = {
                     "chmod",
                     "+x",
+                    "--",
                     scriptFilePath,
                 },
                 CreateNoWindow = true,
@@ -130,6 +131,7 @@ echo 'Update completed successfully.'
             FileName = "/usr/bin/env",
             ArgumentList = {
                 "sh",
+                "--",
                 scriptFilePath,
             },
             CreateNoWindow = false,

--- a/WheelWizard/Services/Installation/AutoUpdater/AutoUpdaterLinux.cs
+++ b/WheelWizard/Services/Installation/AutoUpdater/AutoUpdaterLinux.cs
@@ -25,7 +25,7 @@ public class AutoUpdaterLinux : IUpdaterPlatform
         {
             identifier = "WheelWizard_Linux";
         }
-        
+
         return release.Assets.FirstOrDefault(asset =>
             asset.BrowserDownloadUrl.Contains(identifier, StringComparison.OrdinalIgnoreCase));
     }
@@ -84,7 +84,7 @@ public class AutoUpdaterLinux : IUpdaterPlatform
         var originalFileName = Path.GetFileName(currentFilePath);
         var newFileName = Path.GetFileName(newFilePath);
 
-        var scriptContent = $@"#!/bin/bash
+        var scriptContent = $@"#!/usr/bin/env sh
 echo 'Starting update process...'
 
 # Give a short delay to ensure the application has exited

--- a/WheelWizard/Services/Installation/RetroRewindInstaller.cs
+++ b/WheelWizard/Services/Installation/RetroRewindInstaller.cs
@@ -108,7 +108,8 @@ public static class RetroRewindInstaller
         var rrWfcPaths = new[]
         {
             Path.Combine(PathManager.SaveFolderPath),
-            Path.Combine(PathManager.LoadFolderPath, "Riivolution", "save", "RetroWFC")
+            Path.Combine(PathManager.LoadFolderPath, "Riivolution", "save", "RetroWFC"),
+            Path.Combine(PathManager.LoadFolderPath, "riivolution", "Save", "RetroWFC"),
         };
 
         foreach (var rrWfc in rrWfcPaths)

--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 using WheelWizard.Services.Settings;
 using WheelWizard.Views.Popups.Generic;
 
@@ -25,24 +26,20 @@ public static class DolphinLaunchHelper
             var startInfo = new ProcessStartInfo();
 
             var dolphinLocation = (string)SettingsManager.DOLPHIN_LOCATION.Get();
-            if (dolphinLocation.Contains("flatpak"))
-            {
-                startInfo.FileName = "flatpak";
-                startInfo.Arguments = $"run org.DolphinEmu.dolphin-emu {arguments}";
-                startInfo.UseShellExecute = false;
-            }
-            else if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
-            {
-                startInfo.FileName = "/usr/bin/env";
-                startInfo.Arguments = $"sh -c \"{dolphinLocation} {arguments}\"";
-                startInfo.UseShellExecute = false;
-            }
-            else
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Windows builds
                 startInfo.FileName = dolphinLocation;
                 startInfo.Arguments = arguments;
                 startInfo.UseShellExecute = shellExecute;
+            }
+            else
+            {
+                startInfo.FileName = "/usr/bin/env";
+                startInfo.ArgumentList.Add("sh");
+                startInfo.ArgumentList.Add("-c");
+                startInfo.ArgumentList.Add($"{dolphinLocation} {arguments}");
+                startInfo.UseShellExecute = false;
             }
 
             Process.Start(startInfo);

--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -19,13 +19,13 @@ public static class DolphinLaunchHelper
             process.Kill();
         }
     }
-    
+
     public static void LaunchDolphin(string arguments = "", bool shellExecute = false)
     {
         try
         {
             var startInfo = new ProcessStartInfo();
-            
+
             var dolphinLocation = (string)SettingsManager.DOLPHIN_LOCATION.Get();
             if (dolphinLocation.Contains("flatpak"))
             {
@@ -35,8 +35,8 @@ public static class DolphinLaunchHelper
             }
             else if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
             {
-                startInfo.FileName = "/bin/bash";
-                startInfo.Arguments = $"-c \"{dolphinLocation} {arguments}\"";
+                startInfo.FileName = "/usr/bin/env";
+                startInfo.Arguments = $"sh -c \"{dolphinLocation} {arguments}\"";
                 startInfo.UseShellExecute = false;
             }
             else

--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -38,6 +38,7 @@ public static class DolphinLaunchHelper
                 startInfo.FileName = "/usr/bin/env";
                 startInfo.ArgumentList.Add("sh");
                 startInfo.ArgumentList.Add("-c");
+                startInfo.ArgumentList.Add("--");
                 startInfo.ArgumentList.Add($"{dolphinLocation} {arguments}");
                 startInfo.UseShellExecute = false;
             }

--- a/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
@@ -30,6 +30,6 @@ public static class MiiChannelLaunchHelper
         }
 
         if(miiChannelExists)
-            DolphinLaunchHelper.LaunchDolphin($"-b '{MiiChannelPath}'");
+            DolphinLaunchHelper.LaunchDolphin($"-b \"{MiiChannelPath}\"");
     }
 }

--- a/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
@@ -30,6 +30,6 @@ public static class MiiChannelLaunchHelper
         }
 
         if(miiChannelExists)
-            DolphinLaunchHelper.LaunchDolphin($"-b \"{MiiChannelPath}\"");
+            DolphinLaunchHelper.LaunchDolphin($"-b '{MiiChannelPath}'");
     }
 }

--- a/WheelWizard/Services/Launcher/RrLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrLauncher.cs
@@ -37,7 +37,7 @@ public class RrLauncher : ILauncher
             RetroRewindLaunchHelper.GenerateLaunchJson();
             var dolphinLaunchType = (bool)SettingsManager.LAUNCH_WITH_DOLPHIN.Get() ? "" : "-b";
             DolphinLaunchHelper.LaunchDolphin(
-                $"{dolphinLaunchType} -e '{RrLaunchJsonFilePath}' --config=Dolphin.Core.EnableCheats=False"
+                $"{dolphinLaunchType} -e \"{RrLaunchJsonFilePath}\" --config=Dolphin.Core.EnableCheats=False"
                 );
         }
         catch (Exception ex)

--- a/WheelWizard/Services/Launcher/RrLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrLauncher.cs
@@ -13,7 +13,7 @@ public class RrLauncher : ILauncher
 {
     public string GameTitle { get; } = "RetroRewind";
     private static string RrLaunchJsonFilePath => Path.Combine(PathManager.WheelWizardAppdataPath, "RR.json");
-    
+
     public async Task Launch()
     {
         try
@@ -33,11 +33,11 @@ public class RrLauncher : ILauncher
                 });
                 return;
             }
-            
+
             RetroRewindLaunchHelper.GenerateLaunchJson();
             var dolphinLaunchType = (bool)SettingsManager.LAUNCH_WITH_DOLPHIN.Get() ? "" : "-b";
             DolphinLaunchHelper.LaunchDolphin(
-                $"{dolphinLaunchType} -e \"{RrLaunchJsonFilePath}\" --config=Dolphin.Core.EnableCheats=False"
+                $"{dolphinLaunchType} -e '{RrLaunchJsonFilePath}' --config=Dolphin.Core.EnableCheats=False"
                 );
         }
         catch (Exception ex)
@@ -57,7 +57,7 @@ public class RrLauncher : ILauncher
 
     public async Task<WheelWizardStatus> GetCurrentStatus()
     {
-        if (!SettingsHelper.PathsSetupCorrectly()) 
+        if (!SettingsHelper.PathsSetupCorrectly())
             return WheelWizardStatus.ConfigNotFinished;
 
         var serverEnabled = await HttpClientHelper.GetAsync<string>(Endpoints.RRUrl);
@@ -67,7 +67,7 @@ public class RrLauncher : ILauncher
             return rrInstalled ? WheelWizardStatus.NoServerButInstalled : WheelWizardStatus.NoServer;
 
         if (!rrInstalled) return WheelWizardStatus.NotInstalled;
-        
+
         var retroRewindUpToDate = await RetroRewindUpdater.IsRRUpToDate(RetroRewindInstaller.CurrentRRVersion());
         return !retroRewindUpToDate ? WheelWizardStatus.OutOfDate : WheelWizardStatus.Ready;
     }

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -81,6 +81,7 @@ public static class PathManager
     {
         if (OperatingSystem.IsMacOS())
         {
+            // TODO: Check if we don't actually need this anymore and spaces in paths work
             //return Path.Combine(HomeFolderPath, ".config"); // ~ is the home directory
         }
         return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -79,8 +79,8 @@ public static class PathManager
     private static string LinuxDolphinRelSubFolderPath => "dolphin-emu";
 
     private static string LinuxDolphinFlatpakAppDataFolderPath => Path.Combine(HomeFolderPath, ".var", "app", "org.DolphinEmu.dolphin-emu");
-    private static string LinuxDolphinFlatpakDataDir => Path.Combine(LinuxDolphinFlatpakAppDataFolderPath, "data", LinuxDolphinRelSubFolderPath);
-    private static string LinuxDolphinFlatpakConfigDir => Path.Combine(LinuxDolphinFlatpakAppDataFolderPath, "config", LinuxDolphinRelSubFolderPath);
+    public static string LinuxDolphinFlatpakDataDir => Path.Combine(LinuxDolphinFlatpakAppDataFolderPath, "data", LinuxDolphinRelSubFolderPath);
+    public static string LinuxDolphinFlatpakConfigDir => Path.Combine(LinuxDolphinFlatpakAppDataFolderPath, "config", LinuxDolphinRelSubFolderPath);
 
     private static string EmptyLinuxPathIfRelative(string path)
     {
@@ -188,7 +188,7 @@ public static class PathManager
         return true;
     }
 
-    private static bool IsFlatpakDolphinFilePath()
+    public static bool IsFlatpakDolphinFilePath()
     {
         return IsFlatpakDolphinFilePath(DolphinFilePath);
     }

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -58,7 +58,8 @@ public static class PathManager
                 ArgumentList = {
                     "sh",
                     "-c",
-                    $"command -v ${command}",
+                    "--",
+                    $"command -v -- ${command}",
                 },
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -88,14 +88,14 @@ public static class PathManager
         return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
     }
 
-    // helper paths for folders used across multiple files
+    // Helper paths for folders used across multiple files
     public static string MyStuffFolderPath => Path.Combine(RetroRewind6FolderPath, "MyStuff");
     public static string GetModDirectoryPath(string modName) => Path.Combine(ModsFolderPath, modName);
     public static string RiivolutionWhWzFolderPath => Path.Combine(LoadFolderPath, "Riivolution", "WheelWizard");
     public static string RetroRewind6FolderPath => Path.Combine(RiivolutionWhWzFolderPath, "RetroRewind6");
 
-    //this is not the folder your save file is located in, but its the folder where every Region folder is, so the save file is in SaveFolderPath/Region
-    public static string SaveFolderPath => Path.Combine(RiivolutionWhWzFolderPath, "riivolution", "Save" ,"RetroWFC");
+    // This is not the folder your save file is located in, but its the folder where every Region folder is, so the save file is in SaveFolderPath/Region
+    public static string SaveFolderPath => Path.Combine(RiivolutionWhWzFolderPath, "riivolution", "save" ,"RetroWFC");
 
     public static string LinuxDolphinFullConfigSubFolderPath
     {

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -59,7 +59,7 @@ public static class PathManager
                     "sh",
                     "-c",
                     "--",
-                    $"command -v -- ${command}",
+                    $"command -v -- {command}",
                 },
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -208,10 +208,14 @@ public static class PathManager
 
     private static string? TryFindLinuxNativeUserFolderPath()
     {
-        if (Directory.Exists(LinuxHostXdgConfigHome) && Directory.Exists(LinuxHostXdgDataHome))
+        if (IsFlatpakSandboxed)
         {
-            if (Directory.Exists(LinuxDolphinHostNativeInstallConfigDir) && Directory.Exists(LinuxDolphinHostNativeInstallDataDir))
-                return LinuxDolphinHostNativeInstallDataDir;
+            if (Directory.Exists(LinuxHostXdgConfigHome) && Directory.Exists(LinuxHostXdgDataHome))
+            {
+                if (Directory.Exists(LinuxDolphinHostNativeInstallConfigDir) && Directory.Exists(LinuxDolphinHostNativeInstallDataDir))
+                    return LinuxDolphinHostNativeInstallDataDir;
+            }
+            return null;
         }
 
         if (Directory.Exists(LinuxDolphinNativeInstallConfigDir) && Directory.Exists(LinuxDolphinNativeInstallDataDir))

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using WheelWizard.Helpers;
 using WheelWizard.Services.Settings;
@@ -47,6 +48,33 @@ public static class PathManager
     //When launching we want to move the mods from the Mods folder to the MyStuff folder since that is the folder the game uses
     //Also remember that mods may not be in a subfolder, all mod files must be located in /MyStuff directly
 
+    public static bool IsValidUnixCommand(string command)
+    {
+        try
+        {
+            var processInfo = new ProcessStartInfo
+            {
+                FileName = "/usr/bin/env",
+                ArgumentList = {
+                    "sh",
+                    "-c",
+                    $"command -v ${command}",
+                },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(processInfo);
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     // Keep config in ~/.config for macOS
     private static string GetAppDataFolder()

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -83,7 +83,7 @@ public static class PathManager
         if (OperatingSystem.IsMacOS())
         {
             // TODO: Check if we don't actually need this anymore and spaces in paths work
-            //return Path.Combine(HomeFolderPath, ".config"); // ~ is the home directory
+            return Path.Combine(HomeFolderPath, ".config"); // ~ is the home directory
         }
         return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
     }

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -87,10 +87,12 @@ public static class PathManager
         return path.StartsWith('/') ? path : string.Empty;
     }
 
+    private static bool IsFlatpakSandboxed => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("FLATPAK_ID"));
+
     private static string LinuxXdgDataHome => LocalAppDataFolder;
     private static string LinuxXdgConfigHome => AppDataFolder;
-    private static string LinuxHostXdgDataHome => EmptyLinuxPathIfRelative(Environment.GetEnvironmentVariable("HOST_XDG_DATA_HOME") ?? string.Empty);
-    private static string LinuxHostXdgConfigHome => EmptyLinuxPathIfRelative(Environment.GetEnvironmentVariable("HOST_XDG_CONFIG_HOME") ?? string.Empty);
+    private static string LinuxHostXdgDataHome => EmptyLinuxPathIfRelative(Environment.GetEnvironmentVariable("HOST_XDG_DATA_HOME") ?? Path.Combine(HomeFolderPath, ".local", "share"));
+    private static string LinuxHostXdgConfigHome => EmptyLinuxPathIfRelative(Environment.GetEnvironmentVariable("HOST_XDG_CONFIG_HOME") ?? Path.Combine(HomeFolderPath, ".config"));
 
     private static string LinuxDolphinHostNativeInstallConfigDir => Path.Combine(LinuxHostXdgConfigHome, LinuxDolphinRelSubFolderPath);
     private static string LinuxDolphinHostNativeInstallDataDir => Path.Combine(LinuxHostXdgDataHome, LinuxDolphinRelSubFolderPath);
@@ -101,18 +103,19 @@ public static class PathManager
     {
         get
         {
-            if (LinuxDolphinHostNativeInstallDataDir.Equals(UserFolderPath) && !LinuxDolphinNativeInstallDataDir.Equals(UserFolderPath))
+            if (IsFlatpakSandboxed)
             {
-                return LinuxDolphinHostNativeInstallConfigDir;
+                if (LinuxDolphinHostNativeInstallDataDir.Equals(UserFolderPath))
+                {
+                    return LinuxDolphinHostNativeInstallConfigDir;
+                }
             }
             else if (LinuxDolphinNativeInstallDataDir.Equals(UserFolderPath))
             {
                 return LinuxDolphinNativeInstallConfigDir;
             }
-            else
-            {
-                return string.Empty;
-            }
+
+            return string.Empty;
         }
     }
 

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using WheelWizard.Helpers;
 using WheelWizard.Services.Settings;
@@ -17,6 +17,7 @@ public static class PathManager
     public static string DolphinFilePath => (string)SettingsManager.DOLPHIN_LOCATION.Get();
     public static string UserFolderPath => (string)SettingsManager.USER_FOLDER_PATH.Get();
 
+    private static string AppDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
     private static string LinuxDolphinLegacyRelSubFolderPath => ".dolphin-emu";
     private static string LinuxDolphinLegacyFolderPath => Path.Combine(HomeFolderPath, LinuxDolphinLegacyRelSubFolderPath);
     private static string LinuxDolphinRelSubFolderPath => "dolphin-emu";
@@ -34,7 +35,7 @@ public static class PathManager
     private static string LinuxDolphinNativeRelDataSubFolderPath => Path.Combine(".local", "share", LinuxDolphinRelSubFolderPath);
 
     // Wheel wizard's appdata paths  (dont have to be expressions since they dont depend on user input like the others)f
-    public static readonly string WheelWizardAppdataPath = Path.Combine(GetAppDataFolder(), "CT-MKWII");
+    public static readonly string WheelWizardAppdataPath = Path.Combine(AppDataFolder, "CT-MKWII");
     public static readonly string WheelWizardConfigFilePath = Path.Combine(WheelWizardAppdataPath, "config.json");
     public static readonly string ModsFolderPath = Path.Combine(WheelWizardAppdataPath, "Mods");
     public static readonly string ModConfigFilePath = Path.Combine(ModsFolderPath, "modconfig.json");
@@ -75,17 +76,6 @@ public static class PathManager
         {
             return false;
         }
-    }
-
-    // Keep config in ~/.config for macOS
-    private static string GetAppDataFolder()
-    {
-        if (OperatingSystem.IsMacOS())
-        {
-            // TODO: Check if we don't actually need this anymore and spaces in paths work
-            return Path.Combine(HomeFolderPath, ".config"); // ~ is the home directory
-        }
-        return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
     }
 
     // Helper paths for folders used across multiple files
@@ -147,7 +137,6 @@ public static class PathManager
     {
         get
         {
-            // TODO: Check if this path is valid on macOS
             return Path.Combine(UserFolderPath, "Wii");
         }
     }
@@ -213,12 +202,12 @@ public static class PathManager
 
     public static string? TryFindUserFolderPath()
     {
-        var appDataPath = Path.Combine(GetAppDataFolder(), "Dolphin Emulator");
+        var appDataPath = Path.Combine(AppDataFolder, "Dolphin Emulator");
         if (FileHelper.DirectoryExists(appDataPath))
             return appDataPath;
 
         // Macos path
-        var libraryPath = Path.Combine(GetAppDataFolder(), "Dolphin");
+        var libraryPath = Path.Combine(AppDataFolder, "Dolphin");
         if (FileHelper.DirectoryExists(libraryPath))
             return libraryPath;
 

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -45,15 +45,15 @@ public static class PathManager
 
     //In case it is unclear, the mods folder is a folder with mods that are desired to be installed (if enabled)
     //When launching we want to move the mods from the Mods folder to the MyStuff folder since that is the folder the game uses
-    //Also remember that mods may not be in a subfolder, all mod files must be located in /MyStuff directly 
+    //Also remember that mods may not be in a subfolder, all mod files must be located in /MyStuff directly
 
-  
+
     // Keep config in ~/.config for macOS
     private static string GetAppDataFolder()
     {
         if (OperatingSystem.IsMacOS())
         {
-            return Path.Combine(HomeFolderPath, ".config"); // ~ is the home directory
+            //return Path.Combine(HomeFolderPath, ".config"); // ~ is the home directory
         }
         return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
     }

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -105,9 +105,13 @@ public static class PathManager
             {
                 return LinuxDolphinHostNativeInstallConfigDir;
             }
-            else
+            else if (LinuxDolphinNativeInstallDataDir.Equals(UserFolderPath))
             {
                 return LinuxDolphinNativeInstallConfigDir;
+            }
+            else
+            {
+                return string.Empty;
             }
         }
     }

--- a/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
+++ b/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using WheelWizard.Helpers;
+using WheelWizard.Services;
 using WheelWizard.Views.Popups.Generic;
 
 namespace WheelWizard.Services.Settings;
@@ -10,26 +11,7 @@ public static class LinuxDolphinInstaller
 {
     public static bool IsValidCommand(string command)
     {
-        try
-        {
-            var processInfo = new ProcessStartInfo
-            {
-                FileName = "/usr/bin/env",
-                Arguments = $"sh -c \"command -v {command.Split(' ').First()}\"",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-
-            using var process = Process.Start(processInfo);
-            process.WaitForExit();
-            return process.ExitCode == 0;
-        }
-        catch
-        {
-            return false;
-        }
+        return PathManager.IsValidUnixCommand(command);
     }
 
     public static bool IsDolphinInstalledInFlatpak()

--- a/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
+++ b/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
@@ -209,35 +209,4 @@ public static class LinuxDolphinInstaller
         return true;
     }
 
-
-    //this should return null if not found since functions above require it
-    public static string? TryFindUserFolderPath()
-    {
-        // Get the user's home directory.
-        var home = Environment.GetEnvironmentVariable("HOME");
-        if (string.IsNullOrEmpty(home))
-            return null;
-
-        // First, try the default Flatpak location.
-        var flatpakUserFolder = Path.Combine(home, ".var", "app", "org.DolphinEmu.dolphin-emu");
-        if (Directory.Exists(flatpakUserFolder))
-            return flatpakUserFolder;
-
-        // Next, check if there's an override provided via FLATPAK_USER_DIR.
-        var flatpakOverride = Environment.GetEnvironmentVariable("FLATPAK_USER_DIR");
-        if (!string.IsNullOrEmpty(flatpakOverride))
-        {
-            // Often the structure remains the same.
-            flatpakUserFolder = Path.Combine(flatpakOverride, "org.DolphinEmu.dolphin-emu");
-            if (Directory.Exists(flatpakUserFolder))
-                return flatpakUserFolder;
-        }
-
-        var manualInstall = Path.Combine(home, ".dolphin-emu");
-        if (Directory.Exists(manualInstall))
-            return manualInstall;
-
-        // If not found, return null.
-        return null;
-    }
 }

--- a/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
+++ b/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
@@ -18,8 +18,8 @@ public static class LinuxDolphinInstaller
         {
             var processInfo = new ProcessStartInfo
             {
-                FileName = "/bin/sh",
-                Arguments = $"-c \"command -v {command.Split(' ').First()}\"",
+                FileName = "/usr/bin/env",
+                Arguments = $"sh -c \"command -v {command.Split(' ').First()}\"",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
@@ -208,8 +208,8 @@ public static class LinuxDolphinInstaller
 
         return true;
     }
-    
-    
+
+
     //this should return null if not found since functions above require it
     public static string? TryFindUserFolderPath()
     {

--- a/WheelWizard/Services/Settings/SettingsManager.cs
+++ b/WheelWizard/Services/Settings/SettingsManager.cs
@@ -16,6 +16,10 @@ public class SettingsManager
             if (!FileHelper.DirectoryExists(value as string ?? string.Empty))
                 return false;
 
+            // We cannot determine the validity of the user folder path in that case
+            if (string.IsNullOrWhiteSpace(DOLPHIN_LOCATION.Get() as string))
+                return true;
+
             string[] requiredSubdirectories = { PathManager.LoadFolderPath, PathManager.ConfigFolderPath, PathManager.WiiFolderPath };
             foreach (string requiredSubdirectory in requiredSubdirectories)
             {

--- a/WheelWizard/Services/Settings/SettingsManager.cs
+++ b/WheelWizard/Services/Settings/SettingsManager.cs
@@ -1,5 +1,6 @@
-using WheelWizard.Models.Enums;
+using System;
 using System.Runtime.InteropServices;
+using WheelWizard.Models.Enums;
 using WheelWizard.Helpers;
 using WheelWizard.Models.Settings;
 using WheelWizard.Services;
@@ -37,13 +38,17 @@ public class SettingsManager
             var pathOrCommand = value as string ?? string.Empty;
             if (string.IsNullOrWhiteSpace(pathOrCommand))
                 return false;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+
+            if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX)
             {
-                if (PathManager.IsFlatpakDolphinFilePath(pathOrCommand) && !LinuxDolphinInstaller.IsDolphinInstalledInFlatpak())
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    return false;
+                    if (PathManager.IsFlatpakDolphinFilePath(pathOrCommand) && !LinuxDolphinInstaller.IsDolphinInstalledInFlatpak())
+                    {
+                        return false;
+                    }
                 }
-                return FileHelper.FileExists(pathOrCommand) || LinuxDolphinInstaller.IsValidCommand(pathOrCommand);
+                return FileHelper.FileExists(pathOrCommand) || PathManager.IsValidUnixCommand(pathOrCommand);
             }
 
             return FileHelper.FileExists(pathOrCommand);

--- a/WheelWizard/Services/Settings/SettingsManager.cs
+++ b/WheelWizard/Services/Settings/SettingsManager.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using WheelWizard.Helpers;
 using WheelWizard.Models.Settings;
+using WheelWizard.Services;
 using WheelWizard.Services.Other;
 
 namespace WheelWizard.Services.Settings;
@@ -10,9 +11,23 @@ namespace WheelWizard.Services.Settings;
 public class SettingsManager
 {
     #region Wheel Wizard Settings
-    public static Setting USER_FOLDER_PATH = new WhWzSetting(typeof(string),"UserFolderPath", "").SetValidation(value => FileHelper.DirectoryExists(value as string ?? string.Empty));
-    
-    
+    public static Setting USER_FOLDER_PATH = new WhWzSetting(typeof(string),"UserFolderPath", "")
+        .SetValidation(value =>
+        {
+            if (!FileHelper.DirectoryExists(value as string ?? string.Empty))
+                return false;
+
+            string[] requiredSubdirectories = { PathManager.LoadFolderPath, PathManager.ConfigFolderPath, PathManager.WiiFolderPath };
+            foreach (string requiredSubdirectory in requiredSubdirectories)
+            {
+                if (!FileHelper.DirectoryExists(requiredSubdirectory))
+                    return false;
+            }
+
+            return true;
+        });
+
+
     public static Setting DOLPHIN_LOCATION = new WhWzSetting(typeof(string), "DolphinLocation", "")
         .SetValidation(value =>
         {
@@ -20,12 +35,18 @@ public class SettingsManager
             if (string.IsNullOrWhiteSpace(pathOrCommand))
                 return false;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                if (PathManager.IsFlatpakDolphinFilePath(pathOrCommand) && !LinuxDolphinInstaller.IsDolphinInstalledInFlatpak())
+                {
+                    return false;
+                }
                 return FileHelper.FileExists(pathOrCommand) || LinuxDolphinInstaller.IsValidCommand(pathOrCommand);
-            
+            }
+
             return FileHelper.FileExists(pathOrCommand);
         });
-    
-    
+
+
     public static Setting GAME_LOCATION = new WhWzSetting(typeof(string),"GameLocation", "").SetValidation(value => FileHelper.FileExists(value as string ?? string.Empty));
     public static Setting FORCE_WIIMOTE = new WhWzSetting(typeof(bool),"ForceWiimote", false);
     public static Setting LAUNCH_WITH_DOLPHIN = new WhWzSetting(typeof(bool),"LaunchWithDolphin", false);
@@ -39,14 +60,14 @@ public class SettingsManager
     public static Setting RR_REGION = new WhWzSetting(typeof(MarioKartWiiEnums.Regions), "RR_Region", RRRegionManager.GetValidRegions().First());
     public static Setting WW_LANGUAGE = new WhWzSetting(typeof(string), "WW_Language", "en").SetValidation(value => SettingValues.WhWzLanguages.ContainsKey((string)value!));
     #endregion
-    
+
     #region Dolphin Settings
     public static Setting VSYNC = new DolphinSetting(typeof(bool), ("GFX.ini", "Hardware", "VSync"), false);
     public static Setting INTERNAL_RESOLUTION = new DolphinSetting(typeof(int), ("GFX.ini", "Settings", "InternalResolution"), 1)
         .SetValidation(value => (int)(value ?? -1) >= 0);
     public static Setting SHOW_FPS = new DolphinSetting(typeof(bool), ("GFX.ini", "Settings", "ShowFPS"), false);
     public static Setting GFX_BACKEND = new DolphinSetting(typeof(string), ("Dolphin.ini", "Core", "GFXBackend"), SettingValues.GFXRenderers.Values.First());
-    
+
     //recommended settings
     private static Setting DOLPHIN_COMPILATION_MODE = new DolphinSetting(typeof(DolphinShaderCompilationMode), ("GFX.ini", "Settings", "ShaderCompilationMode"),
         DolphinShaderCompilationMode.Default);
@@ -55,15 +76,15 @@ public class SettingsManager
     private static Setting DOLPHIN_MSAA = new DolphinSetting(typeof(string), ("GFX.ini", "Settings", "MSAA"), "0x00000001").SetValidation(
         value => ( value?.ToString() ?? "") is "0x00000001" or "0x00000002" or "0x00000004" or "0x00000008");
     #endregion
-    
+
     #region Virtual Settings
     private static double _internalScale = -1.0;
-    public static Setting WINDOW_SCALE = new VirtualSetting(typeof(double), 
+    public static Setting WINDOW_SCALE = new VirtualSetting(typeof(double),
                                                             value => _internalScale = (double)value!,
                                                             () => _internalScale == -1.0 ? SAVED_WINDOW_SCALE.Get() : _internalScale
                                                             ).SetDependencies(SAVED_WINDOW_SCALE);
-    
-    
+
+
     public static Setting RECOMMENDED_SETTINGS = new VirtualSetting(typeof(bool), value => {
                                                                 var newValue = (bool)value!;
                                                                 DOLPHIN_COMPILATION_MODE.Set(newValue ? DolphinShaderCompilationMode.HybridUberShaders : DolphinShaderCompilationMode.Default);
@@ -87,8 +108,8 @@ public class SettingsManager
     private static RrGameMode _internalRrGameMode = RrGameMode.RETRO_TRACKS;
     #endregion
 
-    
-    #region Base Settings Manager 
+
+    #region Base Settings Manager
     // dont ever make this a static class, it is required to be an instance class to ensure all settings are loaded
     public static SettingsManager Instance { get; } = new();
     private SettingsManager() { }

--- a/WheelWizard/Services/Settings/SettingsManager.cs
+++ b/WheelWizard/Services/Settings/SettingsManager.cs
@@ -14,7 +14,8 @@ public class SettingsManager
     public static Setting USER_FOLDER_PATH = new WhWzSetting(typeof(string),"UserFolderPath", "")
         .SetValidation(value =>
         {
-            if (!FileHelper.DirectoryExists(value as string ?? string.Empty))
+            var userFolderPath = value as string ?? string.Empty;
+            if (!FileHelper.DirectoryExists(userFolderPath))
                 return false;
 
             // We cannot determine the validity of the user folder path in that case
@@ -26,6 +27,13 @@ public class SettingsManager
             {
                 if (!FileHelper.DirectoryExists(requiredSubdirectory))
                     return false;
+            }
+
+            if (PathManager.IsFlatpakDolphinFilePath() &&
+                !(PathManager.LinuxDolphinFlatpakDataDir.Equals(userFolderPath) &&
+                  PathManager.LinuxDolphinFlatpakConfigDir.Equals(PathManager.ConfigFolderPath)))
+            {
+                return false;
             }
 
             return true;

--- a/WheelWizard/Services/Storage/FilePickerHelper.cs
+++ b/WheelWizard/Services/Storage/FilePickerHelper.cs
@@ -102,6 +102,8 @@ public static class FilePickerHelper
         }
         else if (OperatingSystem.IsMacOS())
         {
+            // Ensures the ~/Library/Application Support/ folder is escaped properly
+            folderPath = $"\"{folderPath}\"";
             Process.Start("open", folderPath);
         }
         else

--- a/WheelWizard/Services/UrlProtocol/UrlProtocolManager.cs
+++ b/WheelWizard/Services/UrlProtocol/UrlProtocolManager.cs
@@ -1,6 +1,7 @@
 ﻿#if WINDOWS
 using Microsoft.Win32;
 #endif
+using System.Diagnostics;
 using WheelWizard.Views.Popups.Generic;
 using WheelWizard.Views.Popups.ModManagement;
 

--- a/WheelWizard/Services/WiiManagement/SaveData/GameDataLoader.cs
+++ b/WheelWizard/Services/WiiManagement/SaveData/GameDataLoader.cs
@@ -25,7 +25,7 @@ public class GameDataLoader : RepeatedTaskManager
     {
         get
         {
-            if (string.IsNullOrWhiteSpace(PathManager.RiivolutionWhWzFolderPath))
+            if (string.IsNullOrWhiteSpace(PathManager.UserFolderPath))
                 return string.Empty;
             if (Directory.Exists(PathManager.SaveFolderPath)) 
                 return PathManager.SaveFolderPath;

--- a/WheelWizard/Services/WiiManagement/SaveData/GameDataLoader.cs
+++ b/WheelWizard/Services/WiiManagement/SaveData/GameDataLoader.cs
@@ -21,7 +21,7 @@ public class GameDataLoader : RepeatedTaskManager
     /// The path to where the “rksys.dat” folder structure is expected to live, e.g.
     ///   ..\path\to\Riivolution\riivolution\save\RetroWFC\RMCP\rksys.dat
     /// </summary>
-    private static string? SaveFilePath
+    private static string? TryCreateSaveFolderPath
     {
         get
         {
@@ -35,8 +35,8 @@ public class GameDataLoader : RepeatedTaskManager
             }
             catch (Exception ex)
             {
-                //do nothing until user directory is resolved.
-                return null;
+                // Do nothing until user directory is resolved.
+                return string.Empty;
             }
             return PathManager.SaveFolderPath;
         }
@@ -276,7 +276,7 @@ public class GameDataLoader : RepeatedTaskManager
     {
         try
         {
-            if (!Directory.Exists(SaveFilePath))
+            if (!Directory.Exists(TryCreateSaveFolderPath))
                 return null;
 
             var currentRegion = (MarioKartWiiEnums.Regions)SettingsManager.RR_REGION.Get();
@@ -295,7 +295,7 @@ public class GameDataLoader : RepeatedTaskManager
                 }
             }
 
-            var saveFileFolder = Path.Combine(SaveFilePath, RRRegionManager.ConvertRegionToGameId(currentRegion));
+            var saveFileFolder = Path.Combine(TryCreateSaveFolderPath, RRRegionManager.ConvertRegionToGameId(currentRegion));
             var saveFile = Directory.GetFiles(saveFileFolder, "rksys.dat", SearchOption.TopDirectoryOnly);
             return saveFile.Length == 0 ? null : File.ReadAllBytes(saveFile[0]);
         }
@@ -449,10 +449,10 @@ public class GameDataLoader : RepeatedTaskManager
     
     private bool SaveRksysToFile()
     {
-        if (_saveData == null || SaveFilePath == null) return false;
+        if (_saveData == null || string.IsNullOrWhiteSpace(TryCreateSaveFolderPath)) return false;
         FixRksysCrc(_saveData);
         var currentRegion = (MarioKartWiiEnums.Regions)SettingsManager.RR_REGION.Get();
-        var saveFolder = Path.Combine(SaveFilePath, RRRegionManager.ConvertRegionToGameId(currentRegion));
+        var saveFolder = Path.Combine(TryCreateSaveFolderPath, RRRegionManager.ConvertRegionToGameId(currentRegion));
 
         try
         {

--- a/WheelWizard/Views/Pages/Settings/WhWzSettings.axaml.cs
+++ b/WheelWizard/Views/Pages/Settings/WhWzSettings.axaml.cs
@@ -94,7 +94,7 @@ public partial class WhWzSettings : UserControl
             if (!IsFlatpakDolphinInstalled())
             {
                 var wantsAutomaticInstall = await new YesNoWindow()
-                    .SetMainText("Invalid configuration.")
+                    .SetMainText("Dolphin Flatpak Installation")
                     .SetExtraText(
                         "The flatpak version of Dolphin Emulator does not appear to be installed. Would you like us to install it?")
                     .SetButtonText("Install", "Manual").AwaitAnswer();

--- a/WheelWizard/Views/Pages/Settings/WhWzSettings.axaml.cs
+++ b/WheelWizard/Views/Pages/Settings/WhWzSettings.axaml.cs
@@ -63,12 +63,24 @@ public partial class WhWzSettings : UserControl
     {
         if (DolphinExeInput.Text != "")
             return;
-        
+
         var folderPath = PathManager.TryFindUserFolderPath();
         if (!string.IsNullOrEmpty(folderPath))
             DolphinUserPathInput.Text = folderPath;
     }
 
+    private string WrapOnWhiteSpace(string inputText)
+    {
+        if (inputText.Any(character => Char.IsWhiteSpace(character)))
+            return $"\"{inputText}\"";
+
+        return inputText;
+    }
+
+    private async void AssignWrappedDolphinExeInput(string inputText)
+    {
+        DolphinExeInput.Text = WrapOnWhiteSpace(inputText);
+    }
 
     private async void DolphinExeBrowse_OnClick(object sender, RoutedEventArgs e)
     {
@@ -138,7 +150,7 @@ public partial class WhWzSettings : UserControl
 
                 if (result)
                 {
-                    DolphinExeInput.Text = dolphinAppPath;
+                    AssignWrappedDolphinExeInput(dolphinAppPath);
                     return;
                 }
             }
@@ -156,7 +168,7 @@ public partial class WhWzSettings : UserControl
             if (folders.Count >= 1)
             {
                 var executablePath = Path.Combine(folders[0].Path.LocalPath, "Contents", "MacOS", "Dolphin");
-                DolphinExeInput.Text = executablePath;
+                AssignWrappedDolphinExeInput(executablePath);
             }
             return; // do not do normal selection for MacOS
         }
@@ -164,7 +176,15 @@ public partial class WhWzSettings : UserControl
         var filePath = await FilePickerHelper.OpenSingleFileAsync("Select Dolphin Emulator", new[] { executableFileType });
         if (!string.IsNullOrEmpty(filePath))
         {
-            DolphinExeInput.Text = filePath;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // On Windows, the file path is directly used as the executable, not in some command
+                DolphinExeInput.Text = filePath;
+            }
+            else
+            {
+                AssignWrappedDolphinExeInput(filePath);
+            }
         }
     }
 

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # https://avaloniaui.net/blog/the-definitive-guide-to-building-and-deploying-avalonia-applications-for-macos
 
 PROJECT_NAME="$1"


### PR DESCRIPTION
- **Purpose of this PR:** Fix the path handling on Linux to use the folders in the same way Dolphin users would expect them to be handled. Flatpak builds should now also work as expected. The broader goal is also to fix the handling of spaces in paths on all platforms (especially on macOS, to drop the `~/.config` directory in favor of `~/Library/Application Support`).
- **How to Test:** For Linux, I tested it on a default Arch Linux image with Plasma installed as a DE using the PKGBUILD of the AUR with a local source `.tar.gz`. Further, I had the Dolphin *natively* installed **and** as a Flatpak to test how it behaves. To test the handling of spaces, a test user can be created to test the Dolphin user folder path. The Dolphin executable path can also be tested with a symlink containing a space, which is automatically getting quoted after browsing. Both single and double quotes are supported for the executable command. Additionally, environment variables (such as `QT_QPA_PLATFORM=xcb`) can be specified. On Windows, to test the handling of spaces, a temporary user with a space in the user name can be created (it does work). Using `Procmon64.exe`, the command line of the Dolphin process can be inspected (the RR config is wrapped using double quotes there as expected).
- **What Has Been Changed:** Depending on the Dolphin run command in the settings, the "config" directory is now determined based on whether it is a Flatpak run command or a native binary. The "Dolphin User Folder" is now expected to be `~/.local/share/dolphin-emu` (as you would get with Dolphin -> File -> Open User Folder), and not some parent directory of that. The right config directory is dynamically determined based on its knowledge about running Flatpak or not (it would use `~/.var/app/org.DolphinEmu.dolphin-emu/data/dolphin-emu` in that case). Apart from that, bugs related to the "browse" button behavior were fixed, such as the browse button for the executable not working on Linux. Spaces in executable paths are handled appropriately now on non-Windows platforms, since they are part of command, not just file paths. To support both types of quotes, the calls to start processes were overhauled, mainly using `ArgumentList` now. Also, the user folder browse button will always prompt the user whether they want to use the automatically found directory.
- **Related Issue:** #46
