### PR TITLE
fix: Use correct options and subcommands for all package managers

### DIFF
--- a/WheelWizard/Helpers/EnvHelper.cs
+++ b/WheelWizard/Helpers/EnvHelper.cs
@@ -4,12 +4,13 @@ namespace WheelWizard.Helpers;
 
 public static class EnvHelper
 {
-    public static string DetectLinuxPackageManager()
+    public static string DetectLinuxPackageManagerInstallCommand()
     {
-        if (LinuxDolphinInstaller.IsValidCommand("apt")) return "apt-get";
-        if (LinuxDolphinInstaller.IsValidCommand("dnf")) return "dnf";
-        if (LinuxDolphinInstaller.IsValidCommand("yum")) return "yum";
-        if (LinuxDolphinInstaller.IsValidCommand("pacman")) return "pacman -S";
-        return LinuxDolphinInstaller.IsValidCommand("zypper") ? "zypper" : string.Empty; // Unknown package manager
+        if (LinuxDolphinInstaller.IsValidCommand("apt")) return "apt install -y";
+        if (LinuxDolphinInstaller.IsValidCommand("apt-get")) return "apt-get -y install";
+        if (LinuxDolphinInstaller.IsValidCommand("dnf")) return "dnf -y install";
+        if (LinuxDolphinInstaller.IsValidCommand("yum")) return "yum -y install";
+        if (LinuxDolphinInstaller.IsValidCommand("pacman")) return "pacman --noconfirm -S";
+        return LinuxDolphinInstaller.IsValidCommand("zypper") ? "zypper --non-interactive install" : string.Empty; // Unknown package manager
     }
 }

--- a/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
+++ b/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
@@ -124,12 +124,12 @@ public static class LinuxDolphinInstaller
             return true;
 
         // Detect the package manager
-        var packageManager = EnvHelper.DetectLinuxPackageManager();
-        if (string.IsNullOrEmpty(packageManager))
+        var packageManagerCommand = EnvHelper.DetectLinuxPackageManagerInstallCommand();
+        if (string.IsNullOrEmpty(packageManagerCommand))
             return false; // Unsupported distro
 
         // Install Flatpak
-        var exitCode = await RunProcessWithProgressAsync("pkexec", $"{packageManager} install -y flatpak", progress);
+        var exitCode = await RunProcessWithProgressAsync("pkexec", $"{packageManagerCommand} flatpak", progress);
         if (exitCode is 127 or 126) //this is error unauthorized
         {
             Dispatcher.UIThread.InvokeAsync(() =>


### PR DESCRIPTION
- **Purpose of this PR:** Fix the way Linux package managers are called to install the `flatpak` package.
- **How to Test:** On any Arch Linux image, the fact that `pacman -S install -y flatpak` will lead to some error message can be reproduced.
- **What Has Been Changed:** The method in `EnvHelper` now returns the right  command with all required flags, handling `pacman` differently. The returned value is just concatenated with `" flatpak"` and that is used to install the package now.
- **Related Issue:** #59
