### PR TITLE
Directory traversal attack prevention in zip extraction

### DIFF
--- a/WheelWizard/Services/Installation/RetroRewindUpdater.cs
+++ b/WheelWizard/Services/Installation/RetroRewindUpdater.cs
@@ -249,7 +249,7 @@ public static class RetroRewindUpdater
         using var archive = ZipFile.OpenRead(path);
 
         // Absolute path of the destination directory
-        var absoluteDestinationPath = Path.GetFullPath(destinationDirectory + Path.DirectorySeparatorChar);
+        var absoluteDestinationPath = Path.GetFullPath(destinationDirectory + Path.AltDirectorySeparatorChar);
 
         foreach (var entry in archive.Entries)
         {

--- a/WheelWizard/Services/Installation/RetroRewindUpdater.cs
+++ b/WheelWizard/Services/Installation/RetroRewindUpdater.cs
@@ -267,7 +267,7 @@ public static class RetroRewindUpdater
             }
 
             // If the entry is a directory, create it
-            if (entry.FullName.EndsWith(Path.DirectorySeparatorChar))
+            if (entry.FullName.EndsWith(Path.AltDirectorySeparatorChar))
             {
                 Directory.CreateDirectory(destinationPath);
                 continue;


### PR DESCRIPTION
The zip extraction of the Retro Rewind updater had a directory traversal attack vector which has now been fixed.