### PR TITLE
fix: Specify `StartupWMClass` for correct window association

### DIFF
--- a/Flatpak/io.github.TeamWheelWizard.WheelWizard.desktop
+++ b/Flatpak/io.github.TeamWheelWizard.WheelWizard.desktop
@@ -5,6 +5,7 @@ Exec=WheelWizard
 Terminal=false
 Type=Application
 Categories=Game;
+StartupWMClass=WheelWizard
 Name=Wheel Wizard
 GenericName=Mario Kart Wii Mod Manager
 Comment=Mario Kart Wii Mod Manager & Retro Rewind Auto Updater


### PR DESCRIPTION
This is a small fix that should fix the window managers' associations to the WheelWizard windows (e.g. in the task bar).