### PR TITLE
feat: Improve relative paths and enable overriding the base dir

### DIFF
--- a/WheelWizard/Helpers/EnvHelper.cs
+++ b/WheelWizard/Helpers/EnvHelper.cs
@@ -1,16 +1,62 @@
-﻿using WheelWizard.Services.Settings;
+﻿using System;
+using System.Diagnostics;
 
 namespace WheelWizard.Helpers;
 
 public static class EnvHelper
 {
+    public static bool IsValidUnixCommand(string command)
+    {
+        try
+        {
+            var processInfo = new ProcessStartInfo
+            {
+                FileName = "/usr/bin/env",
+                ArgumentList = {
+                    "sh",
+                    "-c",
+                    "--",
+                    $"command -v -- {command}",
+                },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(processInfo);
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     public static string DetectLinuxPackageManagerInstallCommand()
     {
-        if (LinuxDolphinInstaller.IsValidCommand("apt")) return "apt install -y";
-        if (LinuxDolphinInstaller.IsValidCommand("apt-get")) return "apt-get -y install";
-        if (LinuxDolphinInstaller.IsValidCommand("dnf")) return "dnf -y install";
-        if (LinuxDolphinInstaller.IsValidCommand("yum")) return "yum -y install";
-        if (LinuxDolphinInstaller.IsValidCommand("pacman")) return "pacman --noconfirm -S";
-        return LinuxDolphinInstaller.IsValidCommand("zypper") ? "zypper --non-interactive install" : string.Empty; // Unknown package manager
+        if (IsValidUnixCommand("apt")) return "apt install -y";
+        if (IsValidUnixCommand("apt-get")) return "apt-get -y install";
+        if (IsValidUnixCommand("dnf")) return "dnf -y install";
+        if (IsValidUnixCommand("yum")) return "yum -y install";
+        if (IsValidUnixCommand("pacman")) return "pacman --noconfirm -S";
+        return IsValidUnixCommand("zypper") ? "zypper --non-interactive install" : string.Empty; // Unknown package manager
+    }
+
+    public static bool IsFlatpakSandboxed()
+    {
+        return FileHelper.FileExists("/.flatpak-info") &&
+            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("FLATPAK_ID"));
+    }
+
+    public static bool IsRelativeLinuxPath(string path)
+    {
+        return !path.StartsWith('/');
+    }
+
+    public static string? NullIfRelativeLinuxPath(string path)
+    {
+        return IsRelativeLinuxPath(path) ? null : path;
     }
 }

--- a/WheelWizard/Program.cs
+++ b/WheelWizard/Program.cs
@@ -2,6 +2,8 @@ using Avalonia;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
+using WheelWizard.Helpers;
 using WheelWizard.Services;
 using WheelWizard.Services.Settings;
 using WheelWizard.Services.UrlProtocol;
@@ -24,10 +26,39 @@ public class Program
             .WithInterFont()
             .LogToTrace();
 
+    private static void SetupWorkingDirectory()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && EnvHelper.IsFlatpakSandboxed())
+        {
+            // In this case, we would not want executable directory-relative paths, since this is in `/app/bin`.
+            // We are going to use the home directory instead (this should be the original working directory anyway).
+            Environment.CurrentDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+        else
+        {
+            // Resolve all relative paths based on the WheelWizard executable's directory by default
+            string executableDirectory = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
+            Environment.CurrentDirectory = executableDirectory;
+        }
+
+        // Enable overriding this base/working directory through the `WW_BASEDIR` environment variable
+        // (this can be relative to the default WheelWizard working directory as well).
+        // This override also influences the `portable-ww.txt` portability check.
+        string whWzBaseDir = Environment.GetEnvironmentVariable("WW_BASEDIR") ?? string.Empty;
+        try
+        {
+            string whWzBaseDirAbsolute = Path.GetFullPath(whWzBaseDir);
+            Environment.CurrentDirectory = whWzBaseDirAbsolute;
+        }
+        catch
+        {
+            // Keep the default base/working directory
+        }
+    }
+
     private static void Setup()
     {
-        // Resolve all relative paths based on the WheelWizard executable's directory
-        Environment.CurrentDirectory = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
+        SetupWorkingDirectory();
         SettingsManager.Instance.LoadSettings();
         BadgeManager.Instance.LoadBadges();
         UrlProtocolManager.SetWhWzScheme();

--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using WheelWizard.Helpers;
 using WheelWizard.Services;
 using WheelWizard.Services.Settings;
 using WheelWizard.Views.Popups.Generic;
@@ -29,7 +30,7 @@ public static class DolphinLaunchHelper
             // Because with the file picker on a Flatpak build, we get XDG portal paths like these...
             // We can fix Flatpak Dolphin to gain access to this game file path though.
             string xdgRuntimeDir = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR") ?? string.Empty;
-            if (PathManager.IsRelativeLinuxPath(xdgRuntimeDir))
+            if (EnvHelper.IsRelativeLinuxPath(xdgRuntimeDir))
             {
                 string fixablePattern = @"^/run/user/(\d+)/doc";
                 Regex fixablePatternRegex = new Regex(fixablePattern);

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -2,7 +2,6 @@
 using Microsoft.Win32;
 #endif
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using WheelWizard.Helpers;
@@ -43,35 +42,6 @@ public static class PathManager
     //When launching we want to move the mods from the Mods folder to the MyStuff folder since that is the folder the game uses
     //Also remember that mods may not be in a subfolder, all mod files must be located in /MyStuff directly
 
-    public static bool IsValidUnixCommand(string command)
-    {
-        try
-        {
-            var processInfo = new ProcessStartInfo
-            {
-                FileName = "/usr/bin/env",
-                ArgumentList = {
-                    "sh",
-                    "-c",
-                    "--",
-                    $"command -v -- {command}",
-                },
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-
-            using var process = Process.Start(processInfo);
-            process.WaitForExit();
-            return process.ExitCode == 0;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
     // Helper paths for folders used across multiple files
     public static string MyStuffFolderPath => Path.Combine(RetroRewind6FolderPath, "MyStuff");
     public static string GetModDirectoryPath(string modName) => Path.Combine(ModsFolderPath, modName);
@@ -92,20 +62,14 @@ public static class PathManager
     public static string LinuxDolphinFlatpakDataDir => Path.Combine(LinuxDolphinFlatpakAppDataFolderPath, "data", LinuxDolphinRelSubFolderPath);
     public static string LinuxDolphinFlatpakConfigDir => Path.Combine(LinuxDolphinFlatpakAppDataFolderPath, "config", LinuxDolphinRelSubFolderPath);
 
-    public static bool IsRelativeLinuxPath(string path)
-    {
-        return !path.StartsWith('/');
-    }
-
     private static string? NullIfRelativeLinuxPath(string path)
     {
-        return IsRelativeLinuxPath(path) ? null : path;
+        return EnvHelper.NullIfRelativeLinuxPath(path);
     }
 
     private static bool IsFlatpakSandboxed()
     {
-        return File.Exists("/.flatpak-info") &&
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("FLATPAK_ID"));
+        return EnvHelper.IsFlatpakSandboxed();
     }
 
     private static string LinuxXdgDataHome => LocalAppDataFolder;

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -14,7 +14,8 @@ public static class PathManager
     // IMPORTANT: To keep things consistent all paths should be Attrib expressions,
     //            and either end with `FilePath` or `FolderPath`
 
-    private static readonly bool IsPortableWhWz = File.Exists("portable-ww.txt");
+    // Portable WheelWizard config only makes sense on non-Flatpak WheelWizard
+    private static readonly bool IsPortableWhWz = !IsFlatpakSandboxed() && File.Exists("portable-ww.txt");
 
     public static string HomeFolderPath => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
@@ -69,6 +70,9 @@ public static class PathManager
 
     private static bool IsFlatpakSandboxed()
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return false;
+
         return EnvHelper.IsFlatpakSandboxed();
     }
 

--- a/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
+++ b/WheelWizard/Services/Settings/LinuxDolphinInstaller.cs
@@ -8,11 +8,6 @@ namespace WheelWizard.Services.Settings;
 
 public static class LinuxDolphinInstaller
 {
-    public static bool IsValidCommand(string command)
-    {
-        return PathManager.IsValidUnixCommand(command);
-    }
-
     public static bool IsDolphinInstalledInFlatpak()
     {
         try
@@ -91,7 +86,7 @@ public static class LinuxDolphinInstaller
     /// <returns>True if Flatpak is available; otherwise, false.</returns>
     public static bool isFlatPakInstalled()
     {
-        return IsValidCommand("flatpak");
+        return EnvHelper.IsValidUnixCommand("flatpak");
     }
 
     /// <summary>

--- a/WheelWizard/Services/Settings/SettingsManager.cs
+++ b/WheelWizard/Services/Settings/SettingsManager.cs
@@ -80,7 +80,7 @@ public class SettingsManager
                         return false;
                     }
                 }
-                return FileHelper.FileExists(pathOrCommand) || PathManager.IsValidUnixCommand(pathOrCommand);
+                return FileHelper.FileExists(pathOrCommand) || EnvHelper.IsValidUnixCommand(pathOrCommand);
             }
 
             return FileHelper.FileExists(pathOrCommand);


### PR DESCRIPTION
This PR is a small improvement to the way relative paths are already handled.

For Flatpak-sandboxed WheelWizard, this will use `$HOME` as the default base directory for resolving relative paths, while other configurations still default to the directory of the WheelWizard executable. Additionally, this can now be overridden with `WW_BASEDIR`.