### PR TITLE
fix: Update `.metainfo.xml` with next release

### DIFF
--- a/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
+++ b/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
@@ -55,11 +55,7 @@
   </provides>
 
   <releases>
-    <!-- FIXME: Remove this release tag and add the correct one for the first Flatpak release -->
-    <!-- (date format: YYYY-MM-DD) -->
-    <release version="" date="">
-      <description/>
-    </release>
+    <release version="2.1.0" date="2025-04-11"/>
   </releases>
 
   <url type="homepage">https://github.com/TeamWheelWizard/WheelWizard</url>


### PR DESCRIPTION
This is just to keep track of the missing release entry for the next release.

As described in the comment, future releases should be added here as well with their date in addition to bumping the version number of the project (assuming this makes it to `flathub` soon, of course).

Once the next release is known, we can enter these two values (release version + date).