### PR TITLE
fix: Add read-write permissions only after all read-only permissions

### DIFF
--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -85,17 +85,19 @@ public static class DolphinLaunchHelper
                 flatpakRunCommand,
                 $"{flatpakRunCommand} --filesystem=\"{Path.GetFullPath(newFilesystemPerm)}\"{mode}");
         };
+        // Read-only permissions
         if (!TryFixFlatpakGameFileAccess())
         {
             addFilesystemPerm(PathManager.GameFilePath, ":ro");
         }
+        addFilesystemPerm(PathManager.RrLaunchJsonFilePath, ":ro");
+        addFilesystemPerm(PathManager.XmlFilePath, ":ro");
+        addFilesystemPerm(PathManager.RiivolutionWhWzFolderPath, ":ro");
+        // Read-write permissions
         if (!PathManager.LinuxDolphinFlatpakDataDir.Equals(PathManager.UserFolderPath, StringComparison.Ordinal))
         {
             addFilesystemPerm(PathManager.UserFolderPath, ":rw");
         }
-        addFilesystemPerm(PathManager.RrLaunchJsonFilePath, ":ro");
-        addFilesystemPerm(PathManager.XmlFilePath, ":ro");
-        addFilesystemPerm(PathManager.RiivolutionWhWzFolderPath, ":ro");
         addFilesystemPerm(PathManager.SaveFolderPath, ":rw");
         return fixedFlatpakDolphinLocation;
     }


### PR DESCRIPTION
This only reorders the permissions given to the Dolphin Flatpak such that read-only permissions do not affect the required read-write permissions of e.g. the user folder in some weird edge cases.