### PR TITLE
fix: Prevent infinite loading on start page

### DIFF
--- a/WheelWizard/Helpers/HttpClientHelper.cs
+++ b/WheelWizard/Helpers/HttpClientHelper.cs
@@ -17,6 +17,7 @@ public static class HttpClientHelper
     private static readonly Lazy<HttpClient> LazyHttpClient = new(() =>
     {
         var client = new HttpClient();
+        client.Timeout = TimeSpan.FromSeconds(6);
         client.DefaultRequestHeaders.UserAgent.ParseAdd("WheelWizard/2.0");
         return client;
     });


### PR DESCRIPTION
## Purpose of this PR:
fix to make sure it does not infinitly load in the start screen if you dont have internet or smth

###  How to Test:
start the app and make sure everything keeps working

### What Has Been Changed:
added a timeout

### Related Issue Link:
https://discord.com/channels/1253384439937896560/1356337934063632595

## Checklist before merging
- [x] You have created relevant tests
