### PR TITLE
fix: Add `QT_QPA_PLATFORM` environment variable

### DIFF
--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -125,10 +125,12 @@ public static class DolphinLaunchHelper
                 startInfo.ArgumentList.Add("sh");
                 startInfo.ArgumentList.Add("-c");
                 startInfo.ArgumentList.Add("--");
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-                    PathManager.IsFlatpakDolphinFilePath())
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    dolphinLocation = FixFlatpakDolphinPermissions(dolphinLocation);
+                    if (PathManager.IsFlatpakDolphinFilePath())
+                        dolphinLocation = FixFlatpakDolphinPermissions(dolphinLocation);
+                    else
+                        startInfo.EnvironmentVariables["QT_QPA_PLATFORM"] = "xcb";
                 }
                 startInfo.ArgumentList.Add($"{dolphinLocation} {dolphinLaunchArguments}");
                 startInfo.UseShellExecute = false;


### PR DESCRIPTION
## Purpose of this PR:
Expose this environment variable to non-Flatpak Dolphin executables on Linux to fix crashes on Wayland.

###  How to Test:
A machine with a recent KDE Plasma version on Wayland can be used along with a native `dolphin-emu` installation to test that e.g. the Software Renderer backend works to launch Retro Rewind. `/proc/<pid>/environ` with `pid` of the `dolphin-emu` process should show the `QT_QPA_PLATFORM=xcb` environment variable. I've tested this and it works.

### What Has Been Changed:
The Dolphin launcher will now add this environment variable where needed on Linux systems to the launched process.

### Related Issue Link:
#95

## Checklist before merging
- [X] You have created relevant tests
