### PR TITLE
fix: Handle the case of a corrupt JSON config

### DIFF
--- a/WheelWizard/Program.cs
+++ b/WheelWizard/Program.cs
@@ -15,12 +15,10 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        var serviceProvider = BuildServiceProvider();
-
-        Setup(serviceProvider);
-
+        // Make sure this is the first action on startup!
+        SetupWorkingDirectory();
         // Start the application
-        BuildAvaloniaApp(serviceProvider).StartWithClassicDesktopLifetime(args);
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
     }
 
     private static ServiceProvider BuildServiceProvider()
@@ -34,13 +32,14 @@ public class Program
 
     // Avalonia configuration, don't remove; also used by visual designer.
     // ReSharper disable once MemberCanBePrivate.Global
-    public static AppBuilder BuildAvaloniaApp(ServiceProvider serviceProvider)
+    public static AppBuilder BuildAvaloniaApp()
         => ConfigureAvaloniaApp(AppBuilder.Configure<App>()
             .UsePlatformDetect()
-            .WithInterFont(), serviceProvider);
+            .WithInterFont());
 
-    private static AppBuilder ConfigureAvaloniaApp(AppBuilder builder, ServiceProvider serviceProvider)
+    private static AppBuilder ConfigureAvaloniaApp(AppBuilder builder)
     {
+        var serviceProvider = BuildServiceProvider();
         // Write startup message
         var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
         LogPlatformInformation(logger);
@@ -56,6 +55,8 @@ public class Program
 
             // Set the service provider in the application instance
             app.SetServiceProvider(serviceProvider);
+
+            Setup();
         });
 
         return builder;
@@ -92,10 +93,9 @@ public class Program
         }
     }
 
-    private static void Setup(ServiceProvider serviceProvider)
+    private static void Setup()
     {
-        SetupWorkingDirectory();
-        SettingsManager.Instance.LoadSettings(serviceProvider);
+        SettingsManager.Instance.LoadSettings();
         UrlProtocolManager.SetWhWzScheme();
     }
 

--- a/WheelWizard/Program.cs
+++ b/WheelWizard/Program.cs
@@ -56,6 +56,9 @@ public class Program
             // Set the service provider in the application instance
             app.SetServiceProvider(serviceProvider);
 
+            // Make sure this comes AFTER setting the service provider
+            // of the `App` instance! Otherwise, things like logging will not work
+            // in `Setup`.
             Setup();
         });
 

--- a/WheelWizard/Program.cs
+++ b/WheelWizard/Program.cs
@@ -15,27 +15,32 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        Setup();
+        var serviceProvider = BuildServiceProvider();
+
+        Setup(serviceProvider);
 
         // Start the application
-        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        BuildAvaloniaApp(serviceProvider).StartWithClassicDesktopLifetime(args);
     }
 
-    // Avalonia configuration, don't remove; also used by visual designer.
-    // ReSharper disable once MemberCanBePrivate.Global
-    public static AppBuilder BuildAvaloniaApp()
-        => ConfigureAvaloniaApp(AppBuilder.Configure<App>()
-            .UsePlatformDetect()
-            .WithInterFont()
-        );
-
-    private static AppBuilder ConfigureAvaloniaApp(AppBuilder builder)
+    private static ServiceProvider BuildServiceProvider()
     {
         var services = new ServiceCollection();
         services.AddWheelWizardServices();
 
         var serviceProvider = services.BuildServiceProvider();
+        return serviceProvider;
+    }
 
+    // Avalonia configuration, don't remove; also used by visual designer.
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static AppBuilder BuildAvaloniaApp(ServiceProvider serviceProvider)
+        => ConfigureAvaloniaApp(AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont(), serviceProvider);
+
+    private static AppBuilder ConfigureAvaloniaApp(AppBuilder builder, ServiceProvider serviceProvider)
+    {
         // Write startup message
         var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
         LogPlatformInformation(logger);
@@ -87,10 +92,10 @@ public class Program
         }
     }
 
-    private static void Setup()
+    private static void Setup(ServiceProvider serviceProvider)
     {
         SetupWorkingDirectory();
-        SettingsManager.Instance.LoadSettings();
+        SettingsManager.Instance.LoadSettings(serviceProvider);
         UrlProtocolManager.SetWhWzScheme();
     }
 

--- a/WheelWizard/Services/Settings/SettingsManager.cs
+++ b/WheelWizard/Services/Settings/SettingsManager.cs
@@ -154,9 +154,9 @@ public class SettingsManager
     public static SettingsManager Instance { get; } = new();
     private SettingsManager() { }
     // dont make this a static method
-    public void LoadSettings()
+    public void LoadSettings(ServiceProvider serviceProvider)
     {
-        WhWzSettingManager.Instance.LoadSettings();
+        WhWzSettingManager.Instance.LoadSettings(serviceProvider);
         DolphinSettingManager.Instance.LoadSettings();
         SettingsHelper.LoadExtraStuff();
     }

--- a/WheelWizard/Services/Settings/SettingsManager.cs
+++ b/WheelWizard/Services/Settings/SettingsManager.cs
@@ -154,9 +154,9 @@ public class SettingsManager
     public static SettingsManager Instance { get; } = new();
     private SettingsManager() { }
     // dont make this a static method
-    public void LoadSettings(ServiceProvider serviceProvider)
+    public void LoadSettings()
     {
-        WhWzSettingManager.Instance.LoadSettings(serviceProvider);
+        WhWzSettingManager.Instance.LoadSettings();
         DolphinSettingManager.Instance.LoadSettings();
         SettingsHelper.LoadExtraStuff();
     }

--- a/WheelWizard/Services/Settings/WhWzSettingManager.cs
+++ b/WheelWizard/Services/Settings/WhWzSettingManager.cs
@@ -39,7 +39,7 @@ public class WhWzSettingManager
         FileHelper.WriteAllTextSafe(PathManager.WheelWizardConfigFilePath, jsonString);
     }
 
-    public void LoadSettings(ServiceProvider serviceProvider)
+    public void LoadSettings()
     {
         if (_loaded)
             return;
@@ -66,7 +66,7 @@ public class WhWzSettingManager
         }
         catch (JsonException e)
         {
-            serviceProvider.GetRequiredService<ILogger<WhWzSettingManager>>()
+            App.Services.GetRequiredService<ILogger<WhWzSettingManager>>()
                 .LogError(e, "Failed to deserialize the JSON config");
         }
     }

--- a/WheelWizard/Services/Settings/WhWzSettingManager.cs
+++ b/WheelWizard/Services/Settings/WhWzSettingManager.cs
@@ -1,6 +1,8 @@
+using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using WheelWizard.Helpers;
 using WheelWizard.Models.Settings;
+using WheelWizard.Views;
 using JsonElement = System.Text.Json.JsonElement;
 using JsonSerializerOptions = System.Text.Json.JsonSerializerOptions;
 
@@ -10,25 +12,25 @@ public class WhWzSettingManager
 {
     private bool _loaded;
     private readonly Dictionary<string, WhWzSetting> _settings = new();
-    
+
     public static WhWzSettingManager Instance { get; } = new();
     private WhWzSettingManager() { }
-    
+
     public void RegisterSetting(WhWzSetting setting)
     {
-        if (_loaded) 
+        if (_loaded)
             return;
-        
+
         _settings.Add(setting.Name, setting);
     }
-    
+
     public void SaveSettings(WhWzSetting invokingSetting)
     {
-        if (!_loaded) 
+        if (!_loaded)
             return;
-        
+
         var settingsToSave = new Dictionary<string, object?>();
-    
+
         foreach (var (name, setting) in _settings)
         {
             settingsToSave[name] = setting.Get();
@@ -36,10 +38,10 @@ public class WhWzSettingManager
         var jsonString = JsonSerializer.Serialize(settingsToSave, new JsonSerializerOptions { WriteIndented = true });
         FileHelper.WriteAllTextSafe(PathManager.WheelWizardConfigFilePath, jsonString);
     }
-    
-    public void LoadSettings()
+
+    public void LoadSettings(ServiceProvider serviceProvider)
     {
-        if (_loaded) 
+        if (_loaded)
             return;
 
         _loaded = true;
@@ -47,18 +49,25 @@ public class WhWzSettingManager
         var jsonString = FileHelper.ReadAllTextSafe(PathManager.WheelWizardConfigFilePath);
         if (jsonString == null)
             return;
-        jsonString.Trim('\0');
-        
-        var loadedSettings = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonString);
-        if (loadedSettings == null) 
-            return;
-        
-        foreach (var kvp in loadedSettings)
+
+        try
         {
-            if (!_settings.TryGetValue(kvp.Key, out var setting))
-                continue;
-            
-            setting.SetFromJson(kvp.Value);
+            var loadedSettings = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(jsonString);
+            if (loadedSettings == null)
+                return;
+
+            foreach (var kvp in loadedSettings)
+            {
+                if (!_settings.TryGetValue(kvp.Key, out var setting))
+                    continue;
+
+                setting.SetFromJson(kvp.Value);
+            }
+        }
+        catch (JsonException e)
+        {
+            serviceProvider.GetRequiredService<ILogger<WhWzSettingManager>>()
+                .LogError(e, "Failed to deserialize the JSON config");
         }
     }
 }


### PR DESCRIPTION
## Purpose of this PR:
Fix the bug where a corrupt `config.json` file (filled with `\0` bytes, for example) would crash WheelWizard.

###  How to Test:
Write a single `\0` byte at the start of the JSON file and remove all other contents. Then open WheelWizard – it should not crash anymore but log the exception and the loaded config is empty. Entering the settings again and hitting save should overwrite the file in a way that the `\0` byte is gone.

### What Has Been Changed:
The initial setup of the application was rewritten to pass the service provider to the `LoadSettings` method (for logging purposes).

### Related Issue Link:
#100

## Checklist before merging
- [x] You have created relevant tests
