### PR TITLE
fix: Allow original mod name in mod installation popup

### DIFF
--- a/WheelWizard/Services/ModManager.cs
+++ b/WheelWizard/Services/ModManager.cs
@@ -83,7 +83,7 @@ public class ModManager : INotifyPropertyChanged
         mod.PropertyChanged += Mod_PropertyChanged;
         Mods.Add(mod);
         SortModsByPriority();
-        SaveModsAsync(); 
+        SaveModsAsync();
     }
 
     public void RemoveMod(Mod mod)
@@ -102,7 +102,7 @@ public class ModManager : INotifyPropertyChanged
             e.PropertyName != nameof(Mod.Author) &&
             e.PropertyName != nameof(Mod.ModID) &&
             e.PropertyName != nameof(Mod.Priority)) return;
-        
+
         SaveModsAsync();
         SortModsByPriority();
     }
@@ -172,7 +172,7 @@ public class ModManager : INotifyPropertyChanged
         _isProcessing = !_isProcessing;
         OnPropertyChanged(nameof(Mods));
     }
-    
+
     public async void RenameMod(Mod selectedMod)
     {
         var oldTitle = selectedMod.Title;
@@ -182,17 +182,17 @@ public class ModManager : INotifyPropertyChanged
             .SetExtraText($"Changing name from: {oldTitle}")
             .SetPlaceholderText("Enter mod name...")
             .ShowDialog();
-        
+
         if (!IsValidName(newTitle)) return;
-        
+
         var oldDirectoryName = PathManager.GetModDirectoryPath(oldTitle);
         var newDirectoryName = PathManager.GetModDirectoryPath(newTitle);
 
         // Check if the old directory exists
         if (!Directory.Exists(oldDirectoryName)) return;
-        
+
         // var oldIniPath = Path.Combine(oldDirectoryName, $"{oldTitle}.ini");
-        
+
         GC.Collect();
         GC.WaitForPendingFinalizers();
 
@@ -229,7 +229,7 @@ public class ModManager : INotifyPropertyChanged
                 Directory.Delete(oldDirectoryName, true);
             }
         }
-     
+
         ReloadAsync();
     }
 
@@ -251,7 +251,7 @@ public class ModManager : INotifyPropertyChanged
             GC.Collect();
             GC.WaitForPendingFinalizers();
             var di = new DirectoryInfo(modDirectory);
-            di.Attributes &= ~FileAttributes.ReadOnly; 
+            di.Attributes &= ~FileAttributes.ReadOnly;
             foreach (var file in di.EnumerateFiles("*", SearchOption.AllDirectories))
             {
                 file.Attributes &= ~FileAttributes.ReadOnly;
@@ -282,11 +282,11 @@ public class ModManager : INotifyPropertyChanged
             ErrorOccurred(Phrases.PopupText_NoModFolder);
         }
     }
-    
+
     public void DeleteModById(int modId)
     {
         var modToDelete = Mods.FirstOrDefault(mod => mod.ModID == modId);
-    
+
         if (modToDelete == null)
         {
             ErrorOccurred($"No mod found with ID: {modId}");
@@ -329,11 +329,11 @@ public class ModManager : INotifyPropertyChanged
     {
         new MessageBoxWindow()
             .SetMessageType(MessageBoxWindow.MessageType.Error)
-            .SetTitleText("An error occured")
+            .SetTitleText("An error occurred")
             .SetInfoText(errorMessage)
             .Show();
     }
-    
+
     #region PropertyChanged
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -363,13 +363,13 @@ public class ModManager : INotifyPropertyChanged
                 .Show();
             return;
         }
- 
+
         // Find mod with next lower priority value
         var modAbove = Mods.Where(m => m.Priority < mod.Priority)
             .OrderByDescending(m => m.Priority)
             .FirstOrDefault();
         if (modAbove == null) return;
-        
+
         (modAbove.Priority, mod.Priority) = (mod.Priority, modAbove.Priority);
 
         SortModsByPriority();
@@ -386,7 +386,7 @@ public class ModManager : INotifyPropertyChanged
                 .Show();
             return;
         }
-    
+
         if (mod.Priority == GetHighestActivePriority() || Mods.Count == 1)
         {
             new MessageBoxWindow()
@@ -396,21 +396,21 @@ public class ModManager : INotifyPropertyChanged
                 .Show();
             return;
         }
-    
+
         // Find mod with next higher priority value
         var modBelow = Mods.Where(m => m.Priority > mod.Priority)
             .OrderBy(m => m.Priority)
             .FirstOrDefault();
-    
+
         if (modBelow == null) return; // Should not happen but just in case
-    
+
         // Swap priorities
         (modBelow.Priority, mod.Priority) = (mod.Priority, modBelow.Priority);
 
         SortModsByPriority();
         SaveModsAsync();
     }
-    
+
     public int GetLowestActivePriority() =>Mods.Min(m => m.Priority);
     public int GetHighestActivePriority() => Mods.Max(m => m.Priority);
 }

--- a/WheelWizard/Views/Popups/DevToolWindow.axaml.cs
+++ b/WheelWizard/Views/Popups/DevToolWindow.axaml.cs
@@ -17,13 +17,13 @@ public partial class DevToolWindow : PopupContent, IRepeatedTaskListener
         AppStateMonitor.Instance.Subscribe(this);
         LoadSettings();
     }
-    
+
     protected override void BeforeClose()
     {
         AppStateMonitor.Instance.Unsubscribe(this);
         base.BeforeClose();
     }
-    
+
     // Yes, it would absolutely be more optimized to insteadof every x seconds refreshing, to just refresh when something changes
     // However, We explicitly do it this way, so all code in the codebase can stay unchanged. The idea is that you can remove the AppStateMonitor and everything will still work
     // This is indeed also possible if you make it if you make everything an observer pattern, where-ever you want to monitor something.
@@ -35,20 +35,20 @@ public partial class DevToolWindow : PopupContent, IRepeatedTaskListener
         MiiImagesCashed.Text = MiiImageManager.ImageCount.ToString();
         MiiParsedDataCashed.Text = MiiImageManager.ParsedMiiDataCount.ToString();
     }
-    
+
     private void LoadSettings()
     {
         WhWzTopMost.IsChecked = ViewUtils.GetLayout().Topmost;
         HttpHelperOff.IsChecked = !HttpClientHelper.FakeConnectionToInternet;
     }
-    
+
     private void WhWzTopMost_OnClick(object sender, RoutedEventArgs e) => ViewUtils.GetLayout().Topmost = WhWzTopMost.IsChecked == true;
     private void HttpHelperOff_OnClick(object sender, RoutedEventArgs e) => HttpClientHelper.FakeConnectionToInternet = HttpHelperOff.IsChecked != true;
     private void ForceEnableLayout_OnClick(object sender, RoutedEventArgs e) => ViewUtils.GetLayout().SetInteractable(true);
 
     private void ClearImageCache_OnClick(object sender, RoutedEventArgs e) => MiiImageManager.ClearImageCache();
-    
-    
+
+
     #region Popup Tests
     private async void TestProgressPopup_OnClick(object sender, RoutedEventArgs e)
     {
@@ -56,7 +56,7 @@ public partial class DevToolWindow : PopupContent, IRepeatedTaskListener
         var progressWindow = new ProgressWindow("test progress !!");
         progressWindow.SetGoal("Setting a goal!");
         progressWindow.Show();
-        
+
         for (var i = 0; i < 5; i++)
         {
             Dispatcher.UIThread.Invoke(() =>
@@ -65,7 +65,7 @@ public partial class DevToolWindow : PopupContent, IRepeatedTaskListener
                 progressWindow.SetExtraText($"This is information for iteration {i}");
                 if(i == 3) progressWindow.SetGoal($"Changed the Goal");
             });
-            await Task.Delay(1000); 
+            await Task.Delay(1000);
         }
         Dispatcher.UIThread.Invoke(() =>
         {
@@ -73,7 +73,7 @@ public partial class DevToolWindow : PopupContent, IRepeatedTaskListener
             ProgressButtonTest.IsEnabled = true;
         });
     }
-    
+
     private void TestMessagePopups_OnClick(object sender, RoutedEventArgs e)
     {
        new MessageBoxWindow()
@@ -81,18 +81,18 @@ public partial class DevToolWindow : PopupContent, IRepeatedTaskListener
             .SetTitleText("Saved Successfully!")
             .SetInfoText("The name you entered has sucessfully saved in the system")
             .Show();
-       
+
        new MessageBoxWindow()
            .SetMessageType(MessageBoxWindow.MessageType.Warning)
            .SetTitleText("Invalid license.")
            .SetInfoText("This license has no Mii data or is incomplete.\n" +
                         "Please use the Mii Channel to create a Mii first. \n \n \n abncd")
            .Show();
-       
+
        new MessageBoxWindow()
            .SetMessageType(MessageBoxWindow.MessageType.Error)
            .SetTitleText("Update error.")
-           .SetInfoText("An error occured when trying top update Retro Rewind.")
+           .SetInfoText("An error occurred when trying to update Retro Rewind.")
            .Show();
     }
 

--- a/WheelWizard/Views/Popups/Generic/TextInputWindow.axaml.cs
+++ b/WheelWizard/Views/Popups/Generic/TextInputWindow.axaml.cs
@@ -10,6 +10,7 @@ public partial class TextInputWindow : PopupContent
 {
     private string? _result;
     private string? initialText;
+    private bool allowInitialText;
     private bool allowCustomChars;
     private TaskCompletionSource<string?>? _tcs;
 
@@ -17,7 +18,7 @@ public partial class TextInputWindow : PopupContent
     public TextInputWindow() : base(true, false, true, "Text Field")
     {
         InitializeComponent();
-   
+
         InputField.TextChanged += InputField_TextChanged;
         UpdateSubmitButtonState();
         SetupCustomChars();
@@ -34,10 +35,16 @@ public partial class TextInputWindow : PopupContent
         InputField.Watermark = placeholder;
         return this;
     }
-    
+
     public TextInputWindow SetExtraText(string extraText)
     {
         ExtraTextBlock.Text = extraText;
+        return this;
+    }
+
+    public TextInputWindow SetAllowInitialText(bool allowInitialText)
+    {
+        this.allowInitialText = allowInitialText;
         return this;
     }
 
@@ -53,25 +60,25 @@ public partial class TextInputWindow : PopupContent
         }
         return this;
     }
-    
+
     public TextInputWindow SetButtonText(string cancelText, string submitText)
     {
         CancelButton.Text = cancelText;
         SubmitButton.Text = submitText;
-        
+
         // It really depends on the text length what looks best
         ButtonContainer.HorizontalAlignment = (submitText.Length + cancelText.Length) > 12
             ? HorizontalAlignment.Stretch : HorizontalAlignment.Right;
         return this;
     }
-    
+
     public TextInputWindow SetInitialText(string text)
     {
         InputField.Text = text;
         initialText = text;
         return this;
     }
-    
+
     public new async Task<string?> ShowDialog()
     {
         _tcs = new TaskCompletionSource<string?>();
@@ -88,8 +95,8 @@ public partial class TextInputWindow : PopupContent
         // f061 up to f06d
         // f074 up to f07c
         // f107 up to f12f
-        // leftovers: e028, e068, e067, e06a, e06b, f030, f031, f034, f035, f038, f039, f03c, f03d, f041, f043, f044, f047, f050, f058, f05e, f05f, f102, f103, 
-        
+        // leftovers: e028, e068, e067, e06a, e06b, f030, f031, f034, f035, f038, f039, f03c, f03d, f041, f043, f044, f047, f050, f058, f05e, f05f, f102, f103,
+
         var chars = new List<char>();
         for (var i = 0x2460; i <= 0x246e; i++)
         {
@@ -116,10 +123,10 @@ public partial class TextInputWindow : PopupContent
             (char)0xe028, (char)0xe068, (char)0xe067, (char)0xe06a, (char)0xe06b,
             (char)0xf030, (char)0xf031, (char)0xf034, (char)0xf035, (char)0xf038,
             (char)0xf039, (char)0xf03c, (char)0xf03d, (char)0xf041, (char)0xf043,
-            (char)0xf044, (char)0xf047, (char)0xf050, (char)0xf058, (char)0xf05e, 
+            (char)0xf044, (char)0xf047, (char)0xf050, (char)0xf058, (char)0xf05e,
             (char)0xf05f, (char)0xf103,
         });
-        
+
         foreach (var c in chars)
         {
             var button = new Button()
@@ -134,7 +141,7 @@ public partial class TextInputWindow : PopupContent
             CustomChars.Children.Add(button);
         }
     }
-    
+
     // Handle text changes to enable/disable Submit button
     private void InputField_TextChanged(object sender, TextChangedEventArgs e)
     {
@@ -146,9 +153,9 @@ public partial class TextInputWindow : PopupContent
     {
         var sameAsInitial = InputField.Text == initialText;
         var empty = string.IsNullOrWhiteSpace(InputField.Text);
-        SubmitButton.IsEnabled = !sameAsInitial && !empty;
+        SubmitButton.IsEnabled = (allowInitialText || !sameAsInitial) && !empty;
     }
-    
+
     private void CustomCharsButton_Click(object sender, EventArgs e)
     {
         CustomChars.IsVisible = true;
@@ -168,8 +175,6 @@ public partial class TextInputWindow : PopupContent
     // Handle Cancel button click
     private void CancelButton_Click(object sender, RoutedEventArgs e)
     {
-        _result = null;
-        _tcs?.TrySetResult(null); // Set the result of the task to null
         Close();
     }
 }

--- a/WheelWizard/Views/Popups/ModManagement/ModDetailViewer.axaml.cs
+++ b/WheelWizard/Views/Popups/ModManagement/ModDetailViewer.axaml.cs
@@ -15,7 +15,7 @@ public partial class ModDetailViewer : UserControl
     private bool loading;
     private bool loadingVisual;
     private GameBananaModDetails? CurrentMod { get; set; }
-    
+
     public ModDetailViewer()
     {
         InitializeComponent();
@@ -59,43 +59,43 @@ public partial class ModDetailViewer : UserControl
         loadingVisual = true;
         loading = true;
         ResetVisibility();
-    
+
         // Retrieve the mod details.
         // If GamebananaSearchHandler.GetModDetailsAsync supports cancellation,
         // consider passing the token as a parameter.
         var modDetailsResult = await GamebananaSearchHandler.GetModDetailsAsync(ModId);
         if (cancellationToken.IsCancellationRequested) return false;
-    
+
         if (!modDetailsResult.Succeeded || modDetailsResult.Content == null)
         {
             CurrentMod = null;
             NoDetailsView.Title = "Failed to retrieve mod info";
             NoDetailsView.BodyText = modDetailsResult.StatusMessage ?? "An error occurred while fetching mod details.";
-            
+
             loading = false;
             loadingVisual = false;
             ResetVisibility();
             return false;
         }
-    
+
         CurrentMod = modDetailsResult.Content;
-    
+
         // Update the UI with mod details
         ModTitle.Text = CurrentMod._sName;
         AuthorButton.Text = CurrentMod._aSubmitter._sName;
         LikesCountBox.Text = CurrentMod._nLikeCount.ToString();
         ViewsCountBox.Text = CurrentMod._nViewCount.ToString();
         DownloadsCountBox.Text = CurrentMod._nDownloadCount.ToString();
-    
+
         // Wrap the mod description in a div tag so that CSS can be applied
         ModDescriptionHtmlPanel.Text = $"<body>{CurrentMod._sText}</body>";
         CurrentMod.OverrideDownloadUrl = newDownloadUrl;
         UpdateDownloadButtonState(ModId);
-    
+
         // Clear any previous images and reset banner visibility
         ImageCarousel.Items.Clear();
         BannerImage.IsVisible = false;
-    
+
         // If there are no images to load, finish up early
         if (CurrentMod._aPreviewMedia?._aImages == null || !CurrentMod._aPreviewMedia._aImages.Any())
         {
@@ -104,32 +104,32 @@ public partial class ModDetailViewer : UserControl
             ResetVisibility();
             return true;
         }
-    
+
         // Load images sequentially
         foreach (var image in CurrentMod._aPreviewMedia._aImages)
         {
             if (cancellationToken.IsCancellationRequested) return false;
-    
+
             var fullImageUrl = $"{image._sBaseUrl}/{image._sFile}";
-    
+
             var streamResult = await HttpClientHelper.GetStreamAsync(fullImageUrl, cancellationToken);
             if (!streamResult.Succeeded || streamResult.Content == null)
             {
                 continue;
             }
-    
+
             // Get the image stream with cancellation support
             await using var stream = streamResult.Content;
             var memoryStream = new MemoryStream();
             await stream.CopyToAsync(memoryStream, cancellationToken);
             memoryStream.Position = 0;
-    
+
             // Create a bitmap from the memory stream
             var bitmap = new Bitmap(memoryStream);
-    
+
             // Add the bitmap to the image carousel
             ImageCarousel.Items.Add(new { FullImageUrl = bitmap });
-    
+
             // Set the first loaded image as the banner if not already set
             if (!BannerImage.IsVisible)
             {
@@ -137,21 +137,21 @@ public partial class ModDetailViewer : UserControl
                 BannerImage.Source = bitmap;
             }
         }
-    
+
         // Reset the loading state once all operations have completed
         loading = false;
         loadingVisual = false;
         ResetVisibility();
-        
+
         return true;
     }
 
-    
+
     private void UpdateDownloadButtonState(int modId)
     {
         var isInstalled = ModManager.Instance.IsModInstalled(modId);
         InstallButton.Content = isInstalled ? "Installed": "Download and Install";
-        InstallButton.IsEnabled = !isInstalled; 
+        InstallButton.IsEnabled = !isInstalled;
         UnInstallButton.IsVisible = isInstalled;
     }
 
@@ -165,20 +165,20 @@ public partial class ModDetailViewer : UserControl
         AuthorButton.Text = "Unknown";
         LikesCountBox.Text = ViewsCountBox.Text = DownloadsCountBox.Text = "0";
         ModDescriptionHtmlPanel.Text = string.Empty;
-        IsVisible = false; 
+        IsVisible = false;
     }
-    
+
     private async void Install_Click(object sender, RoutedEventArgs e)
     {
         var confirmation = await new YesNoWindow()
             .SetMainText($"Do you want to download and install the mod: {CurrentMod._sName}?")
             .AwaitAnswer();
         if (!confirmation) return;
-    
+
         try
         {
             await PrepareToDownloadFile();
-            var downloadUrls = CurrentMod.OverrideDownloadUrl != null 
+            var downloadUrls = CurrentMod.OverrideDownloadUrl != null
                 ? new List<string> { CurrentMod.OverrideDownloadUrl }
                 : CurrentMod._aFiles.Select(f => f._sDownloadUrl).ToList();
             if (!downloadUrls.Any())
@@ -190,7 +190,7 @@ public partial class ModDetailViewer : UserControl
                     .Show();
                 return;
             }
-            
+
             var progressWindow = new ProgressWindow($"Downloading {CurrentMod._sName}");
             progressWindow.Show();
             progressWindow.SetExtraText("Loading...");
@@ -213,12 +213,13 @@ public partial class ModDetailViewer : UserControl
             var author = "-1";
             if (CurrentMod._aSubmitter?._sName != null)
                 author = CurrentMod._aSubmitter._sName;
-            
+
             var modId = CurrentMod._idRow;
             var popup = new TextInputWindow()
                 .SetMainText("Mod Name")
                 .SetInitialText(CurrentMod._sName)
-                .SetPlaceholderText("Enter mod name...");
+                .SetPlaceholderText("Enter mod name...")
+                .SetAllowInitialText(true);
             var modName = await popup.ShowDialog();
             if (string.IsNullOrEmpty(modName))
             {
@@ -300,7 +301,7 @@ public partial class ModDetailViewer : UserControl
         var url = $"https://gamebanana.com/support/add?s=Mod.{CurrentMod._idRow}";
         ViewUtils.OpenLink(url);
     }
-    
+
     private void UnInstall_Click(object sender, RoutedEventArgs e)
     {
         ModManager.Instance.DeleteModById(CurrentMod._idRow);


### PR DESCRIPTION
## Purpose of this PR:
Fix the issue where the original mod name cannot be used when installing a mod. Additionally, the purpose is to fix the "Cancel" button behavior s.t. it acts just like the window's close button (no error popup). 

###  How to Test:
Install a new mod – there the "Submit" button should work for the initial name. For other popups like the renaming of the mod, the "Submit" button should still be grayed out. Hitting "Cancel" should not lead to error popups anymore, but still cancel the operation (nothing happens).

### What Has Been Changed:
The `TextInputWindow` class has been changed to support allowing the initial input. Furthermore, the "Cancel" button action has been changed s.t. it only closes the window without returning a result.

### Related Issue Link:
#102

## Checklist before merging
- [X] You have created relevant tests
