### PR TITLE
Operationresult exception handling

### DIFF
--- a/WheelWizard.Test/GlobalUsings.cs
+++ b/WheelWizard.Test/GlobalUsings.cs
@@ -1,1 +1,2 @@
 ﻿global using NSubstitute;
+global using static WheelWizard.Shared.OperationResult;

--- a/WheelWizard.Test/Shared/OperationResult/OperationResultTests.cs
+++ b/WheelWizard.Test/Shared/OperationResult/OperationResultTests.cs
@@ -1,6 +1,6 @@
 ﻿using WheelWizard.Shared;
 
-namespace WheelWizard.Test;
+namespace WheelWizard.Test.Shared.OperationResultTests;
 
 public class OperationResultTests
 {
@@ -88,7 +88,7 @@ public class OperationResultTests
         Assert.True(operationResult.IsSuccess);
         Assert.Equal(value, operationResult.Value);
     }
-    
+
     [Fact(DisplayName = "Create success generic result, should have correct state")]
     public void CreateSuccessGenericResult_ShouldHaveCorrectState()
     {
@@ -104,7 +104,7 @@ public class OperationResultTests
         Assert.True(operationResult.IsSuccess);
         Assert.Equal(value, operationResult.Value);
     }
-    
+
     [Fact(DisplayName = "New failure generic result, should have correct state")]
     public void NewFailureGenericResult_ShouldHaveCorrectState()
     {
@@ -119,7 +119,7 @@ public class OperationResultTests
         Assert.True(operationResult.IsFailure);
         Assert.False(operationResult.IsSuccess);
     }
-    
+
     [Fact(DisplayName = "Create failure generic result, should have correct state")]
     public void CreateFailureGenericResult_ShouldHaveCorrectState()
     {
@@ -134,7 +134,7 @@ public class OperationResultTests
         Assert.True(operationResult.IsFailure);
         Assert.False(operationResult.IsSuccess);
     }
-    
+
     [Fact(DisplayName = "Implicit generic result from error, should have correct state")]
     public void ImplicitGenericResultFromError_ShouldHaveCorrectState()
     {
@@ -149,7 +149,7 @@ public class OperationResultTests
         Assert.True(operationResult.IsFailure);
         Assert.False(operationResult.IsSuccess);
     }
-    
+
     [Fact(DisplayName = "Implicit generic result from value, should have correct state")]
     public void ImplicitGenericResultFromValue_ShouldHaveCorrectState()
     {
@@ -164,5 +164,118 @@ public class OperationResultTests
         Assert.False(operationResult.IsFailure);
         Assert.True(operationResult.IsSuccess);
         Assert.Equal(value, operationResult.Value);
+    }
+    
+    [Fact(DisplayName = "Implicit result from string, should have failed state")]
+    public void ImplicitResultFromString_ShouldHaveFailedState()
+    {
+        // Arrange
+        const string errorMessage = "Error message";
+
+        // Act
+        OperationResult operationResult = errorMessage;
+
+        // Assert
+        Assert.NotNull(operationResult.Error);
+        Assert.True(operationResult.IsFailure);
+        Assert.False(operationResult.IsSuccess);
+        Assert.Equal(errorMessage, operationResult.Error?.Message);
+    }
+    
+    [Fact(DisplayName = "Implicit result from exception, should have failed state")]
+    public void ImplicitResultFromException_ShouldHaveFailedState()
+    {
+        // Arrange
+        var exception = new Exception("Error message");
+
+        // Act
+        OperationResult operationResult = exception;
+
+        // Assert
+        Assert.NotNull(operationResult.Error);
+        Assert.True(operationResult.IsFailure);
+        Assert.False(operationResult.IsSuccess);
+        Assert.Equal(exception.Message, operationResult.Error?.Message);
+    }
+
+    [Fact(DisplayName = "Implicit generic result from string, should have correct failed state")]
+    public void ImplicitGenericResultFromString_ShouldHaveCorrectFailedState()
+    {
+        // Arrange
+        const string errorMessage = "Error message";
+
+        // Act
+        OperationResult<object> operationResult = errorMessage;
+
+        // Assert
+        Assert.NotNull(operationResult.Error);
+        Assert.True(operationResult.IsFailure);
+        Assert.False(operationResult.IsSuccess);
+        Assert.Equal(errorMessage, operationResult.Error?.Message);
+    }
+
+    [Fact(DisplayName = "Implicit generic result from exception, should have correct failed state")]
+    public void ImplicitGenericResultFromException_ShouldHaveCorrectFailedState()
+    {
+        // Arrange
+        var exception = new Exception("Error message");
+
+        // Act
+        OperationResult<object> operationResult = exception;
+
+        // Assert
+        Assert.NotNull(operationResult.Error);
+        Assert.True(operationResult.IsFailure);
+        Assert.False(operationResult.IsSuccess);
+        Assert.Equal(exception.Message, operationResult.Error?.Message);
+    }
+
+    [Fact(DisplayName = "Safe execute without exception, should have correct success state")]
+    public void SafeExecuteWithoutException_ShouldHaveCorrectSuccessState()
+    {
+        // Arrange
+        int Func() => 42;
+
+        // Act
+        var result = OperationResult.SafeExecute(Func);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact(DisplayName = "Safe execute with exception, should have failed state")]
+    public void SafeExecuteWithException_ShouldHaveFailedState()
+    {
+        // Arrange
+        var exception = new Exception("Error message");
+
+        int Func() => throw exception;
+
+        // Act
+        var result = OperationResult.SafeExecute(Func);
+
+        // Assert
+        Assert.True(result.IsFailure);
+        Assert.Equal(exception.Message, result.Error?.Message);
+        Assert.Equal(exception, result.Error?.Exception);
+    }
+
+    [Fact(DisplayName = "Safe execute with exception with override, should have failed state with message")]
+    public void SafeExecuteWithExceptionWithOverride_ShouldHaveFailedStateWithMessage()
+    {
+        // Arrange
+        var exception = new Exception("Error message");
+        const string errorMessage = "Custom error message";
+
+        int Func() => throw exception;
+
+        // Act
+        var result = OperationResult.SafeExecute(Func, errorMessage);
+
+        // Assert
+        Assert.True(result.IsFailure);
+        Assert.Equal(errorMessage, result.Error?.Message);
+        Assert.Equal(exception, result.Error?.Exception);
     }
 }

--- a/WheelWizard.Test/Shared/Services/AvaloniaLoggerAdapterTests.cs
+++ b/WheelWizard.Test/Shared/Services/AvaloniaLoggerAdapterTests.cs
@@ -1,0 +1,94 @@
+using Avalonia;
+using Avalonia.Logging;
+using Microsoft.Extensions.Logging;
+using WheelWizard.Shared.Services;
+
+namespace WheelWizard.Test.Shared.Services;
+
+public class AvaloniaLoggerAdapterTests
+{
+    public static TheoryData<LogEventLevel, LogLevel> LogLevels =
+        new()
+        {
+            { LogEventLevel.Verbose, LogLevel.Trace },
+            { LogEventLevel.Debug, LogLevel.Debug },
+            { LogEventLevel.Information, LogLevel.Information },
+            { LogEventLevel.Warning, LogLevel.Warning },
+            { LogEventLevel.Error, LogLevel.Error },
+            { LogEventLevel.Fatal, LogLevel.Critical }
+        };
+
+    [Theory(DisplayName = "Log adapter message, should convert to logger message")]
+    [MemberData(nameof(LogLevels))]
+    public void LogAdapterMessage_ShouldConvertToLoggerMessage(LogEventLevel level, LogLevel expectedLevel)
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<AvaloniaObject>>();
+        var logAdapter = new AvaloniaLoggerAdapter(logger);
+
+        var args = new object[] { "testValue" };
+
+        // Act
+        logAdapter.Log(level, "TestArea", null, "Test message {Arg}", args);
+
+        // Assert
+        logger.Received(1).Log(expectedLevel, "Test message {Arg}", args);
+    }
+
+    [Fact(DisplayName = "Log adapter without args, should log message without args")]
+    public void LogAdapterWithoutArgs_ShouldLogMessageWithoutArgs()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<AvaloniaObject>>();
+        var logAdapter = new AvaloniaLoggerAdapter(logger);
+
+        // Act
+        logAdapter.Log(LogEventLevel.Information, "TestArea", null, "Test message");
+
+        // Assert
+        logger.Received(1).Log(LogLevel.Information, "Test message");
+    }
+
+    [Fact(DisplayName = "Log adapter with layout area, should not log")]
+    public void LogAdapterWithLayoutArea_ShouldNotLog()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<AvaloniaObject>>();
+        var logAdapter = new AvaloniaLoggerAdapter(logger);
+
+        // Act
+        logAdapter.Log(LogEventLevel.Information, "Layout", null, "Test message");
+
+        // Assert
+#pragma warning disable CA2254
+        // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
+        logger.DidNotReceive().Log(LogLevel.Information, "Test message");
+#pragma warning restore CA2254
+    }
+
+    [Fact(DisplayName = "Log adapter is enabled, should be true")]
+    public void LogAdapterIsEnabled_ShouldBeTrue()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<AvaloniaObject>>();
+        var logAdapter = new AvaloniaLoggerAdapter(logger);
+
+        // Act
+        var result = logAdapter.IsEnabled(LogEventLevel.Information, "TestArea");
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact(DisplayName = "Invalid log event level log, should throw exception")]
+    public void InvalidLogEventLevelLog_ShouldThrowException()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<AvaloniaObject>>();
+        var logAdapter = new AvaloniaLoggerAdapter(logger);
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            logAdapter.Log((LogEventLevel)999, "TestArea", null, "Test message"));
+    }
+}

--- a/WheelWizard/Features/AutoUpdating/Platforms/LinuxUpdatePlatform.cs
+++ b/WheelWizard/Features/AutoUpdating/Platforms/LinuxUpdatePlatform.cs
@@ -30,13 +30,13 @@ public class LinuxUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
     {
         var currentExecutablePath = Environment.ProcessPath;
         if (currentExecutablePath is null)
-            return Fail(Phrases.PopupText_UnableUpdateWhWz_ReasonLocation);
+            return Phrases.PopupText_UnableUpdateWhWz_ReasonLocation;
 
         var currentExecutableName = fileSystem.Path.GetFileName(currentExecutablePath);
         var currentFolder = fileSystem.Path.GetDirectoryName(currentExecutablePath);
 
         if (currentFolder is null)
-            return Fail(Phrases.PopupText_UnableUpdateWhWz_ReasonLocation);
+            return Phrases.PopupText_UnableUpdateWhWz_ReasonLocation;
 
         // Download the new executable to a temporary file.
         var newFilePath = fileSystem.Path.Combine(currentFolder, currentExecutableName + "_new");
@@ -67,7 +67,7 @@ public class LinuxUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
     {
         var currentFolder = fileSystem.Path.GetDirectoryName(currentFilePath);
         if (currentFolder is null)
-            return Fail(Phrases.PopupText_UnableUpdateWhWz_ReasonLocation);
+            return Phrases.PopupText_UnableUpdateWhWz_ReasonLocation;
 
         var scriptFilePath = fileSystem.Path.Combine(currentFolder, "update.sh");
         var originalFileName = fileSystem.Path.GetFileName(currentFilePath);
@@ -98,30 +98,24 @@ public class LinuxUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
         fileSystem.File.WriteAllText(scriptFilePath, scriptContent);
 
         // Ensure the script is executable.
-        try
-        {
-            Process.Start(new ProcessStartInfo
-            {
-                FileName = "/usr/bin/env",
-                ArgumentList =
+        var chmodResult = SafeExecute(() =>
+                Process.Start(new ProcessStartInfo
                 {
-                    "chmod",
-                    "+x",
-                    "--",
-                    scriptFilePath,
-                },
-                CreateNoWindow = true,
-                UseShellExecute = false
-            })?.WaitForExit();
-        }
-        catch (Exception ex)
-        {
-            return Fail(new()
-            {
-                Message = "Failed to set execute permission for the update script.",
-                Exception = ex
-            });
-        }
+                    FileName = "/usr/bin/env",
+                    ArgumentList =
+                    {
+                        "chmod",
+                        "+x",
+                        "--",
+                        scriptFilePath,
+                    },
+                    CreateNoWindow = true,
+                    UseShellExecute = false
+                })?.WaitForExit(), errorMessage: "Failed to set execute permission for the update script."
+        );
+
+        if (chmodResult.IsFailure)
+            return chmodResult;
 
         var processStartInfo = new ProcessStartInfo
         {
@@ -137,19 +131,6 @@ public class LinuxUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             WorkingDirectory = currentFolder
         };
 
-        try
-        {
-            Process.Start(processStartInfo);
-        }
-        catch (Exception ex)
-        {
-            return Fail(new()
-            {
-                Message = "Failed to execute the update script.",
-                Exception = ex
-            });
-        }
-
-        return Ok();
+        return SafeExecute(() => Process.Start(processStartInfo), errorMessage: "Failed to execute the update script.");
     }
 }

--- a/WheelWizard/Features/AutoUpdating/Platforms/LinuxUpdatePlatform.cs
+++ b/WheelWizard/Features/AutoUpdating/Platforms/LinuxUpdatePlatform.cs
@@ -98,7 +98,7 @@ public class LinuxUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
         fileSystem.File.WriteAllText(scriptFilePath, scriptContent);
 
         // Ensure the script is executable.
-        var chmodResult = SafeExecute(() =>
+        var chmodResult = TryCatch(() =>
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = "/usr/bin/env",
@@ -131,6 +131,6 @@ public class LinuxUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             WorkingDirectory = currentFolder
         };
 
-        return SafeExecute(() => Process.Start(processStartInfo), errorMessage: "Failed to execute the update script.");
+        return TryCatch(() => Process.Start(processStartInfo), errorMessage: "Failed to execute the update script.");
     }
 }

--- a/WheelWizard/Features/AutoUpdating/Platforms/WindowsUpdatePlatform.cs
+++ b/WheelWizard/Features/AutoUpdating/Platforms/WindowsUpdatePlatform.cs
@@ -44,7 +44,7 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             Verb = "runas" // This verb asks for elevation.
         };
 
-        return SafeExecute(() =>
+        return TryCatch(() =>
         {
             Process.Start(startInfo);
             Environment.Exit(0);
@@ -174,6 +174,6 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             WorkingDirectory = currentFolder
         };
 
-        return SafeExecute(() => Process.Start(processStartInfo), errorMessage: "Failed to execute the update script.");
+        return TryCatch(() => Process.Start(processStartInfo), errorMessage: "Failed to execute the update script.");
     }
 }

--- a/WheelWizard/Features/AutoUpdating/Platforms/WindowsUpdatePlatform.cs
+++ b/WheelWizard/Features/AutoUpdating/Platforms/WindowsUpdatePlatform.cs
@@ -44,16 +44,11 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             Verb = "runas" // This verb asks for elevation.
         };
 
-        try
+        return SafeExecute(() =>
         {
             Process.Start(startInfo);
             Environment.Exit(0);
-            return Ok();
-        }
-        catch (Exception)
-        {
-            return Phrases.PopupText_RestartAdminFail;
-        }
+        }, errorMessage: Phrases.PopupText_RestartAdminFail);
     }
 
     private static bool IsAdministrator()
@@ -108,7 +103,7 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
     {
         var currentFolder = fileSystem.Path.GetDirectoryName(currentFilePath);
         if (currentFolder is null)
-            return Fail(Phrases.PopupText_UnableUpdateWhWz_ReasonLocation);
+            return Phrases.PopupText_UnableUpdateWhWz_ReasonLocation;
 
         var scriptFilePath = fileSystem.Path.Combine(currentFolder, "update.ps1");
         var originalFileName = fileSystem.Path.GetFileName(currentFilePath);
@@ -179,18 +174,6 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             WorkingDirectory = currentFolder
         };
 
-        try
-        {
-            Process.Start(processStartInfo);
-            return Ok();
-        }
-        catch (Exception ex)
-        {
-            return Fail(new()
-            {
-                Message = "Failed to execute the update script.",
-                Exception = ex
-            });
-        }
+        return SafeExecute(() => Process.Start(processStartInfo), errorMessage: "Failed to execute the update script.");
     }
 }

--- a/WheelWizard/Shared/OperationResult/OperationError.cs
+++ b/WheelWizard/Shared/OperationResult/OperationError.cs
@@ -15,5 +15,15 @@ public class OperationError
     /// </summary>
     public Exception? Exception { get; init; }
 
-    public static implicit operator OperationError(string message) => new() { Message = message };
+    #region Implicit Operators
+
+    public static implicit operator OperationError(string errorMessage) => new() { Message = errorMessage };
+
+    public static implicit operator OperationError(Exception exception) => new()
+    {
+        Message = exception.Message,
+        Exception = exception
+    };
+
+    #endregion
 }

--- a/WheelWizard/Shared/OperationResult/OperationResult.cs
+++ b/WheelWizard/Shared/OperationResult/OperationResult.cs
@@ -82,7 +82,7 @@ public class OperationResult
     /// <param name="errorMessage">The error message to return if the function fails.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>An <see cref="OperationResult{T}"/> that indicates the result of the operation.</returns>
-    public static OperationResult<T> SafeExecute<T>(Func<T> func, string? errorMessage = null)
+    public static OperationResult<T> TryCatch<T>(Func<T> func, string? errorMessage = null)
     {
         try
         {
@@ -107,7 +107,7 @@ public class OperationResult
     /// <param name="errorMessage">The error message to return if the function fails.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>An <see cref="OperationResult{T}"/> that indicates the result of the operation.</returns>
-    public static async Task<OperationResult<T>> SafeExecute<T>(Func<Task<T>> func, string? errorMessage = null)
+    public static async Task<OperationResult<T>> TryCatch<T>(Func<Task<T>> func, string? errorMessage = null)
     {
         try
         {
@@ -131,7 +131,7 @@ public class OperationResult
     /// <param name="action">The action to execute.</param>
     /// <param name="errorMessage">The error message to return if the function fails.</param>
     /// <returns>An <see cref="OperationResult"/> that indicates the result of the operation.</returns>
-    public static OperationResult SafeExecute(Action action, string? errorMessage = null)
+    public static OperationResult TryCatch(Action action, string? errorMessage = null)
     {
         try
         {
@@ -155,7 +155,7 @@ public class OperationResult
     /// <param name="action">The action to execute.</param>
     /// <param name="errorMessage">The error message to return if the function fails.</param>
     /// <returns>An <see cref="OperationResult"/> that indicates the result of the operation.</returns>
-    public static async Task<OperationResult> SafeExecute(Func<Task> action, string? errorMessage = null)
+    public static async Task<OperationResult> TryCatch(Func<Task> action, string? errorMessage = null)
     {
         try
         {

--- a/WheelWizard/Shared/OperationResult/OperationResult.cs
+++ b/WheelWizard/Shared/OperationResult/OperationResult.cs
@@ -64,7 +64,7 @@ public class OperationResult
     /// <param name="error">The error that occurred during the operation.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>A new instance of the <see cref="OperationResult{T}"/> class.</returns>
-    public static OperationResult<T> Fail<T>(OperationError error) where T : notnull => new(error);
+    public static OperationResult<T> Fail<T>(OperationError error) => new(error);
 
     /// <summary>
     /// Creates a new instance of the <see cref="OperationResult{T}"/> class that indicates success.
@@ -72,7 +72,7 @@ public class OperationResult
     /// <param name="value">The value of the operation result.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>A new instance of the <see cref="OperationResult{T}"/> class.</returns>
-    public static OperationResult<T> Ok<T>(T value) where T : notnull => new(value);
+    public static OperationResult<T> Ok<T>(T value) => new(value);
 
     /// <summary>
     /// Executes the specified function and returns the result.
@@ -82,15 +82,89 @@ public class OperationResult
     /// <param name="errorMessage">The error message to return if the function fails.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>An <see cref="OperationResult{T}"/> that indicates the result of the operation.</returns>
-    public static OperationResult<T> SafeExecute<T>(Func<T> func, string? errorMessage = null) where T : notnull
+    public static OperationResult<T> SafeExecute<T>(Func<T> func, string? errorMessage = null)
     {
         try
         {
-            return Ok(func());
+            var value = func();
+            return Ok(value);
         }
         catch (Exception ex)
         {
             return Fail<T>(new()
+            {
+                Message = errorMessage ?? ex.Message,
+                Exception = ex
+            });
+        }
+    }
+
+    /// <summary>
+    /// Executes the specified function and returns the result.
+    /// Catches any exceptions thrown by the function and returns a failure result.
+    /// </summary>
+    /// <param name="func">The function to execute.</param>
+    /// <param name="errorMessage">The error message to return if the function fails.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>An <see cref="OperationResult{T}"/> that indicates the result of the operation.</returns>
+    public static async Task<OperationResult<T>> SafeExecute<T>(Func<Task<T>> func, string? errorMessage = null)
+    {
+        try
+        {
+            var value = await func();
+            return Ok(value);
+        }
+        catch (Exception ex)
+        {
+            return Fail<T>(new()
+            {
+                Message = errorMessage ?? ex.Message,
+                Exception = ex
+            });
+        }
+    }
+
+    /// <summary>
+    /// Executes the specified function and returns the result.
+    /// Catches any exceptions thrown by the function and returns a failure result.
+    /// </summary>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorMessage">The error message to return if the function fails.</param>
+    /// <returns>An <see cref="OperationResult"/> that indicates the result of the operation.</returns>
+    public static OperationResult SafeExecute(Action action, string? errorMessage = null)
+    {
+        try
+        {
+            action();
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            return Fail(new()
+            {
+                Message = errorMessage ?? ex.Message,
+                Exception = ex
+            });
+        }
+    }
+
+    /// <summary>
+    /// Executes the specified function and returns the result.
+    /// Catches any exceptions thrown by the function and returns a failure result.
+    /// </summary>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorMessage">The error message to return if the function fails.</param>
+    /// <returns>An <see cref="OperationResult"/> that indicates the result of the operation.</returns>
+    public static async Task<OperationResult> SafeExecute(Func<Task> action, string? errorMessage = null)
+    {
+        try
+        {
+            await action();
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            return Fail(new()
             {
                 Message = errorMessage ?? ex.Message,
                 Exception = ex

--- a/WheelWizard/Shared/OperationResult/OperationResult.cs
+++ b/WheelWizard/Shared/OperationResult/OperationResult.cs
@@ -43,6 +43,8 @@ public class OperationResult
         Error = error;
     }
 
+    #region Creation Methods
+
     /// <summary>
     /// Creates a new instance of the <see cref="OperationResult"/> class with the specified error.
     /// </summary>
@@ -62,7 +64,7 @@ public class OperationResult
     /// <param name="error">The error that occurred during the operation.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>A new instance of the <see cref="OperationResult{T}"/> class.</returns>
-    public static OperationResult<T> Fail<T>(OperationError error) => new(error);
+    public static OperationResult<T> Fail<T>(OperationError error) where T : notnull => new(error);
 
     /// <summary>
     /// Creates a new instance of the <see cref="OperationResult{T}"/> class that indicates success.
@@ -70,8 +72,41 @@ public class OperationResult
     /// <param name="value">The value of the operation result.</param>
     /// <typeparam name="T">The type of the value.</typeparam>
     /// <returns>A new instance of the <see cref="OperationResult{T}"/> class.</returns>
-    public static OperationResult<T> Ok<T>(T value) => new(value);
+    public static OperationResult<T> Ok<T>(T value) where T : notnull => new(value);
 
-    public static implicit operator OperationResult(OperationError error) => new(error);
-    public static implicit operator OperationResult(string errorMessage) => new(errorMessage);
+    /// <summary>
+    /// Executes the specified function and returns the result.
+    /// Catches any exceptions thrown by the function and returns a failure result.
+    /// </summary>
+    /// <param name="func">The function to execute.</param>
+    /// <param name="errorMessage">The error message to return if the function fails.</param>
+    /// <typeparam name="T">The type of the value.</typeparam>
+    /// <returns>An <see cref="OperationResult{T}"/> that indicates the result of the operation.</returns>
+    public static OperationResult<T> SafeExecute<T>(Func<T> func, string? errorMessage = null) where T : notnull
+    {
+        try
+        {
+            return Ok(func());
+        }
+        catch (Exception ex)
+        {
+            return Fail<T>(new()
+            {
+                Message = errorMessage ?? ex.Message,
+                Exception = ex
+            });
+        }
+    }
+
+    #endregion
+
+    #region Implicit Operators
+
+    public static implicit operator OperationResult(OperationError error) => Fail(error);
+
+    public static implicit operator OperationResult(string errorMessage) => Fail(errorMessage);
+
+    public static implicit operator OperationResult(Exception exception) => Fail(exception);
+
+    #endregion
 }

--- a/WheelWizard/Shared/OperationResult/OperationResult`1.cs
+++ b/WheelWizard/Shared/OperationResult/OperationResult`1.cs
@@ -36,8 +36,15 @@ public class OperationResult<T> : OperationResult
     {
     }
 
-    public static implicit operator OperationResult<T>(OperationError error) => new(error);
-    public static implicit operator OperationResult<T>(string errorMessage) => new(errorMessage);
+    #region Implicit Operators
 
-    public static implicit operator OperationResult<T>(T value) => new(value);
+    public static implicit operator OperationResult<T>(T value) => Ok(value);
+
+    public static implicit operator OperationResult<T>(OperationError error) => Fail<T>(error);
+
+    public static implicit operator OperationResult<T>(string errorMessage) => Fail<T>(errorMessage);
+
+    public static implicit operator OperationResult<T>(Exception exception) => Fail<T>(exception);
+
+    #endregion
 }

--- a/WheelWizard/Shared/OperationResult/OperationResult`1.cs
+++ b/WheelWizard/Shared/OperationResult/OperationResult`1.cs
@@ -1,23 +1,18 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace WheelWizard.Shared;
+﻿namespace WheelWizard.Shared;
 
 /// <summary>
 /// Represents the result of an operation.
 /// </summary>
 /// <typeparam name="T">The type of the value.</typeparam>
-public class OperationResult<T> : OperationResult where T : notnull
+public class OperationResult<T> : OperationResult
 {
-    [MemberNotNullWhen(true, nameof(Value))]
-    public override bool IsSuccess => base.IsSuccess;
-
-    [MemberNotNullWhen(false, nameof(Value))]
-    public override bool IsFailure => base.IsFailure;
+    private readonly T _value;
 
     /// <summary>
     /// The value of the operation result.
     /// </summary>
-    public T? Value { get; }
+    /// <exception cref="InvalidOperationException">Thrown if the operation was not successful.</exception>
+    public T Value => IsSuccess ? _value : throw new InvalidOperationException("The operation was not successful.");
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OperationResult{T}"/> class.
@@ -25,7 +20,7 @@ public class OperationResult<T> : OperationResult where T : notnull
     /// <param name="value">The value of the operation result.</param>
     public OperationResult(T value)
     {
-        Value = value;
+        _value = value;
     }
 
     /// <summary>
@@ -34,6 +29,7 @@ public class OperationResult<T> : OperationResult where T : notnull
     /// <param name="error">The error that occurred during the operation.</param>
     public OperationResult(OperationError error) : base(error)
     {
+        _value = default!;
     }
 
     #region Implicit Operators

--- a/WheelWizard/Shared/OperationResult/OperationResult`1.cs
+++ b/WheelWizard/Shared/OperationResult/OperationResult`1.cs
@@ -6,7 +6,7 @@ namespace WheelWizard.Shared;
 /// Represents the result of an operation.
 /// </summary>
 /// <typeparam name="T">The type of the value.</typeparam>
-public class OperationResult<T> : OperationResult
+public class OperationResult<T> : OperationResult where T : notnull
 {
     [MemberNotNullWhen(true, nameof(Value))]
     public override bool IsSuccess => base.IsSuccess;

--- a/WheelWizard/Shared/Services/ApiCaller.cs
+++ b/WheelWizard/Shared/Services/ApiCaller.cs
@@ -32,7 +32,7 @@ public class ApiCaller<T>(IServiceScopeFactory scopeFactory, ILogger<ApiCaller<T
         using var scope = scopeFactory.CreateScope();
         var api = scope.ServiceProvider.GetRequiredService<T>();
 
-        var result = await SafeExecute(async () => await apiCallFunction.Invoke(api), errorMessage: $"{apiName} call failed");
+        var result = await TryCatch(async () => await apiCallFunction.Invoke(api), errorMessage: $"{apiName} call failed");
         if (!result.IsSuccess)
             logger.LogError(result.Error.Exception, "API method '{ApiCall}' failed: {Message}", apiCallString, result.Error.Message);
 

--- a/WheelWizard/Shared/Services/ApiCaller.cs
+++ b/WheelWizard/Shared/Services/ApiCaller.cs
@@ -12,33 +12,30 @@ public interface IApiCaller<TApi> where TApi : class
     /// <summary>
     /// Calls the specified API method asynchronously.
     /// </summary>
-    /// <param name="apiCall">The API method to call.</param>
+    /// <param name="apiCall">The API method to call. Make sure you name the variable clearly as it is used in the logs.</param>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <returns>An <see cref="OperationResult{TResult}"/> representing the result of the API call.</returns>
-    Task<OperationResult<TResult>> CallApiAsync<TResult>(Expression<Func<TApi, Task<TResult>>> apiCall) where TResult : notnull;
+    /// <remarks>
+    /// Uses the <paramref name="apiCall"/> expression and the name of <typeparamref name="TApi"/> for logging purposes.
+    /// </remarks>
+    Task<OperationResult<TResult>> CallApiAsync<TResult>(Expression<Func<TApi, Task<TResult>>> apiCall);
 }
 
 public class ApiCaller<T>(IServiceScopeFactory scopeFactory, ILogger<ApiCaller<T>> logger) : IApiCaller<T> where T : class
 {
-    public async Task<OperationResult<TResult>> CallApiAsync<TResult>(Expression<Func<T, Task<TResult>>> apiCall) where TResult : notnull
+    public async Task<OperationResult<TResult>> CallApiAsync<TResult>(Expression<Func<T, Task<TResult>>> apiCall)
     {
         var apiCallString = apiCall.Body.ToString();
+        var apiCallFunction = apiCall.Compile();
+        var apiName = typeof(T).Name[1..];
 
-        try
-        {
-            using var scope = scopeFactory.CreateScope();
-            var api = scope.ServiceProvider.GetRequiredService<T>();
+        using var scope = scopeFactory.CreateScope();
+        var api = scope.ServiceProvider.GetRequiredService<T>();
 
-            return Ok(await apiCall.Compile().Invoke(api));
-        }
-        catch (Exception exception)
-        {
-            logger.LogError(exception, "API call '{ApiCall}' failed: {Message}", apiCallString, exception.Message);
-            return new OperationError
-            {
-                Message = $"API call '{apiCallString}' failed: {exception.Message}",
-                Exception = exception
-            };
-        }
+        var result = await SafeExecute(async () => await apiCallFunction.Invoke(api), errorMessage: $"{apiName} call failed");
+        if (!result.IsSuccess)
+            logger.LogError(result.Error.Exception, "API method '{ApiCall}' failed: {Message}", apiCallString, result.Error.Message);
+
+        return result;
     }
 }

--- a/WheelWizard/Shared/Services/ApiCaller.cs
+++ b/WheelWizard/Shared/Services/ApiCaller.cs
@@ -15,12 +15,12 @@ public interface IApiCaller<TApi> where TApi : class
     /// <param name="apiCall">The API method to call.</param>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     /// <returns>An <see cref="OperationResult{TResult}"/> representing the result of the API call.</returns>
-    Task<OperationResult<TResult>> CallApiAsync<TResult>(Expression<Func<TApi, Task<TResult>>> apiCall);
+    Task<OperationResult<TResult>> CallApiAsync<TResult>(Expression<Func<TApi, Task<TResult>>> apiCall) where TResult : notnull;
 }
 
 public class ApiCaller<T>(IServiceScopeFactory scopeFactory, ILogger<ApiCaller<T>> logger) : IApiCaller<T> where T : class
 {
-    public async Task<OperationResult<TResult>> CallApiAsync<TResult>(Expression<Func<T, Task<TResult>>> apiCall)
+    public async Task<OperationResult<TResult>> CallApiAsync<TResult>(Expression<Func<T, Task<TResult>>> apiCall) where TResult : notnull
     {
         var apiCallString = apiCall.Body.ToString();
 
@@ -29,7 +29,7 @@ public class ApiCaller<T>(IServiceScopeFactory scopeFactory, ILogger<ApiCaller<T
             using var scope = scopeFactory.CreateScope();
             var api = scope.ServiceProvider.GetRequiredService<T>();
 
-            return await apiCall.Compile().Invoke(api);
+            return Ok(await apiCall.Compile().Invoke(api));
         }
         catch (Exception exception)
         {


### PR DESCRIPTION
## Purpose of this PR:
Sometimes we need to convert exceptions to operation results.

###  How to Test:
(not applicable)

### What Has Been Changed:
- Added extra exception handling methods to the operation result implementation.
- Made OperationResult<T> have a nullability constraint due to the MemberNotNull attributes

## Checklist before merging
- [X] You have created relevant tests
