### PR TITLE
fix: move the `load settings` location/order

### DIFF
--- a/WheelWizard/Program.cs
+++ b/WheelWizard/Program.cs
@@ -17,6 +17,7 @@ public class Program
     {
         // Make sure this is the first action on startup!
         SetupWorkingDirectory();
+        SettingsManager.Instance.LoadSettings();
         // Start the application
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
     }
@@ -98,7 +99,6 @@ public class Program
 
     private static void Setup()
     {
-        SettingsManager.Instance.LoadSettings();
         UrlProtocolManager.SetWhWzScheme();
     }
 


### PR DESCRIPTION
## Purpose of this PR:
There is a bug where the settings are not properly loaded. This apparently has something to do with the place where it is invoked. I honestly don't know the exact details. I just know that moving it here seemed to fix it.

###  How to Test:
start your program and see that your settings are not constantly dissepearing

### What Has Been Changed:
I move the location where the loadSettings is invoked

### Related Issue Link:

## Checklist before merging
- [X] You have created relevant tests
