### PR TITLE
Fix licences without valid mii not showing

### DIFF
--- a/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
+++ b/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
@@ -193,9 +193,7 @@ public class GameDataSingletonService : RepeatedTaskManager, IGameDataSingletonS
 
         var friendCode = FriendCodeGenerator.GetFriendCode(_saveData, offset + 0x5C);
         var miiDataResult = ParseMiiData(offset + 0x14);
-        var miiToUse = new MiiData() { Mii = new() { Name = new("no name") } };
-        if (miiDataResult.IsSuccess)
-            miiToUse = miiDataResult.Value;
+        var miiToUse = miiDataResult.IsFailure ? new() { Mii = new() { Name = new("no name") } } : miiDataResult.Value;
         var user = new LicenseProfile
         {
             MiiData = miiToUse,

--- a/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
+++ b/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
@@ -193,11 +193,12 @@ public class GameDataSingletonService : RepeatedTaskManager, IGameDataSingletonS
 
         var friendCode = FriendCodeGenerator.GetFriendCode(_saveData, offset + 0x5C);
         var miiDataResult = ParseMiiData(offset + 0x14);
-        if (miiDataResult.IsFailure)
-            return miiDataResult.Error;
+        MiiData miiToUse = new() { Mii = new Mii { Name = new MiiName("no name") } };
+        if (miiDataResult.IsSuccess)
+            miiToUse = miiDataResult.Value;
         var user = new LicenseProfile
         {
-            MiiData = miiDataResult.Value,
+            MiiData = miiToUse,
             FriendCode = friendCode,
             Vr = BigEndianBinaryReader.BufferToUint16(_saveData, offset + 0xB0),
             Br = BigEndianBinaryReader.BufferToUint16(_saveData, offset + 0xB2),

--- a/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
+++ b/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
@@ -193,7 +193,7 @@ public class GameDataSingletonService : RepeatedTaskManager, IGameDataSingletonS
 
         var friendCode = FriendCodeGenerator.GetFriendCode(_saveData, offset + 0x5C);
         var miiDataResult = ParseMiiData(offset + 0x14);
-        MiiData miiToUse = new() { Mii = new Mii { Name = new MiiName("no name") } };
+        var miiToUse = new MiiData() { Mii = new() { Name = new("no name") } };
         if (miiDataResult.IsSuccess)
             miiToUse = miiDataResult.Value;
         var user = new LicenseProfile


### PR DESCRIPTION
### Purpose of this PR:
Fix an issue where licenses with guest Miis were not showing up properly due to failed Mii parsing.

### How to Test:
Load a save file that contains a license with a guest Mii (e.g., a Mii created without a Mii Channel ID).

Confirm that the license now appears in the UI and no exception or error occurs during parsing.

### What Has Been Changed:
Modified the ParseUser method to fall back to a dummy MiiData with placeholder name ("no name") when Mii parsing fails.

Ensures the license is still loaded even if the associated Mii is invalid or missing.

### Related Issue Link:
[Issue #113](https://github.com/TeamWheelWizard/WheelWizard/issues/113)

### Checklist before merging
[not needed] You have created relevant tests