### PR TITLE
My profile fixes

### DIFF
--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -109,6 +109,19 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener, ISettingListene
         }
     }
 
+    public void UpdateFriendCount()
+    {
+        var friends = GameDataService.CurrentFriends;
+        FriendsButton.BoxText = $"{friends.Count(friend => friend.IsOnline)}/{friends.Count}";
+        FriendsButton.BoxTip = friends.Count(friend => friend.IsOnline) switch
+        {
+            1 => Phrases.Hover_FriendsOnline_1,
+            0 => Phrases.Hover_FriendsOnline_0,
+            _ => Humanizer.ReplaceDynamic(Phrases.Hover_FriendsOnline_x, friends.Count(friend => friend.IsOnline)) ??
+                 $"There are currently {friends.Count(friend => friend.IsOnline)} friends online"
+        };
+    }
+
     public void UpdatePlayerAndRoomCount(RRLiveRooms sender)
     {
         var playerCount = sender.PlayerCount;
@@ -129,15 +142,7 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener, ISettingListene
             _ => Humanizer.ReplaceDynamic(Phrases.Hover_RoomsOnline_x, roomCount) ??
                  $"There are currently {roomCount} rooms active"
         };
-        var friends = GameDataService.CurrentFriends;
-        FriendsButton.BoxText = $"{friends.Count(friend => friend.IsOnline)}/{friends.Count}";
-        FriendsButton.BoxTip = friends.Count(friend => friend.IsOnline) switch
-        {
-            1 => Phrases.Hover_FriendsOnline_1,
-            0 => Phrases.Hover_FriendsOnline_0,
-            _ => Humanizer.ReplaceDynamic(Phrases.Hover_FriendsOnline_x, friends.Count(friend => friend.IsOnline)) ??
-                 $"There are currently {friends.Count(friend => friend.IsOnline)} friends online"
-        };
+        UpdateFriendCount();
     }
 
     private void UpdateLiveAlert(WhWzStatusManager sender)

--- a/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
+++ b/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
 using WheelWizard.Models.Enums;
 using WheelWizard.Models.GameData;
 using WheelWizard.Models.MiiImages;
@@ -151,6 +152,9 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
         CurrentUserProfile.IsChecked = true;
         // Even though it's true when this method is called, we still set it to true,
         // since Avalonia has some weird ass cashing, It might just be that that is because this method is actually deprecated
+
+        //now we refresh the sidebar friend amount
+        ViewUtils.GetLayout().UpdateFriendCount();
     }
 
     private void RegionDropdown_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -175,6 +179,7 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
         SetUserAsPrimary();
         UpdatePage();
         NavigationManager.NavigateTo<UserProfilePage>();
+        ViewUtils.GetLayout().UpdateFriendCount();
     }
 
     // This is intentionally a separate validation method besides the true name validation. That name validation allows less than 3.

--- a/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
+++ b/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
@@ -171,10 +171,10 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
             return;
         }
 
-        NavigationManager.NavigateTo<UserProfilePage>();
         ViewMii(0); // Just in case you have current user set as 4. and you change to a region where there are only 3 users.
         SetUserAsPrimary();
         UpdatePage();
+        NavigationManager.NavigateTo<UserProfilePage>();
     }
 
     // This is intentionally a separate validation method besides the true name validation. That name validation allows less than 3.
@@ -186,7 +186,7 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
 
         return Ok();
     }
-    
+
     private async void ChangeMiiName(object? obj, EventArgs e)
     {
         var renamePopup = new TextInputWindow()

--- a/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
+++ b/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
@@ -132,6 +132,7 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
         currentPlayer.PropertyChanged += OnMiiNameChanged;
         CurrentUserProfile.TotalRaces = currentPlayer.TotalRaceCount.ToString();
         CurrentUserProfile.TotalWon = currentPlayer.TotalWinCount.ToString();
+        ResetMiiTopBar();
     }
 
     private void OnMiiNameChanged(object? sender, PropertyChangedEventArgs args)
@@ -178,7 +179,6 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
         ViewMii(0); // Just in case you have current user set as 4. and you change to a region where there are only 3 users.
         SetUserAsPrimary();
         UpdatePage();
-        NavigationManager.NavigateTo<UserProfilePage>();
         ViewUtils.GetLayout().UpdateFriendCount();
     }
 
@@ -216,6 +216,10 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
                 .SetTitleText("Name changed")
                 .SetInfoText($"Successfully changed name to {newName}")
                 .Show();
+
+        //reload game data, since multiple licenses can use the same mii
+        GameDataService.LoadGameData();
+        UpdatePage();
     }
 
     private void ViewRoom_OnClick(string friendCode)


### PR DESCRIPTION
## Purpose of this PR:
Fix a bug,. when you switch your primary license your friendcount would not instantly update
also fixed an edge case when switching regions your selected license would be a no license

###  How to Test:
Have 2 licenses, 1 containing x amount of friends and another containing different amount of friends, switch between them as the primary user. You should see your friendcount in the sidebar update. Same goes for switching regions

### What Has Been Changed:
UpdateFriends has been made its own function to be called. 

### Related Issue Link:
https://github.com/TeamWheelWizard/WheelWizard/issues/115

## Checklist before merging
- [not needed] You have created relevant tests
