### PR TITLE
fix: Improve Mii name and license behavior

### DIFF
--- a/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
+++ b/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
@@ -171,14 +171,21 @@ public class GameDataSingletonService : RepeatedTaskManager, IGameDataSingletonS
             var rkpdOffset = RksysMagic.Length + i * RkpdSize;
             var rkpdCheck = Encoding.ASCII.GetString(_saveData, rkpdOffset, RkpdMagic.Length) == RkpdMagic;
             if (!rkpdCheck)
+            {
+                UserList.Users.Add(CreateDummyUser());
                 continue;
+            }
 
             var user = ParseUser(rkpdOffset);
             if (user.IsFailure)
+            {
+                UserList.Users.Add(CreateDummyUser());
                 continue;
+            }
             UserList.Users.Add(user.Value);
         }
 
+        // Keep this here so we always have 4 users if the code above were to be changed
         while (UserList.Users.Count < 4)
         {
             UserList.Users.Add(CreateDummyUser());

--- a/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
+++ b/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
@@ -94,7 +94,9 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
 
             var itemForRegionDropdown = new ComboBoxItem
             {
-                Content = region.ToString(), Tag = region, IsEnabled = validRegions.Contains(region)
+                Content = region.ToString(),
+                Tag = region,
+                IsEnabled = validRegions.Contains(region)
             };
             RegionDropdown.Items.Add(itemForRegionDropdown);
 
@@ -186,18 +188,21 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
 
         return Ok();
     }
-    
+
     private async void ChangeMiiName(object? obj, EventArgs e)
     {
+        var oldName = CurrentMii?.Name.ToString();
         var renamePopup = new TextInputWindow()
             .SetMainText($"Enter new name")
-            .SetExtraText($"Changing name from: {CurrentMii?.Name}")
+            .SetExtraText($"Changing name from: {oldName}")
             .SetAllowCustomChars(true)
             .SetValidation(ValidateMiiName)
-            .SetInitialText(CurrentMii?.Name.ToString() ?? "")
-            .SetPlaceholderText(CurrentMii?.Name.ToString() ?? "");
+            .SetInitialText(oldName ?? "")
+            .SetPlaceholderText(oldName ?? "");
 
         var newName = await renamePopup.ShowDialog();
+        if (oldName == newName || newName == null)
+            return;
         var changeNameResult = GameDataService.ChangeMiiName(_currentUserIndex, newName);
         if (changeNameResult.IsFailure)
             new MessageBoxWindow()


### PR DESCRIPTION
## Purpose of this PR:
This PR addresses two open issues: the cancel action of Mii renaming (should not do anything) and the order of licenses in the WheelWizard GUI.

###  How to Test:
Open the rename dialog for a mii and cancel – it should now cancel the operation without an additional popup. For the license order, test with an erased license in a spot that's above other existing licenses. The order should be as expected now based on the order in Mario Kart Wii itself. I've tested these cases for myself, and I can confirm they work as expected now.

### What Has Been Changed:
For the renaming, an additional check has been added for no-op renames (same name, `null` if canceled). The parsing of users has been changed such that the order of licenses is the same as in the game itself (adding dummy users directly inside the loop).

### Related PR:
#114

## Checklist before merging
- [X] You have created relevant tests
