### PR TITLE
fix: Create save folder if it does not exist yet when granting Dolphin Flatpak permissions

### DIFF
--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -94,7 +94,7 @@ public static class DolphinLaunchHelper
         addFilesystemPerm(PathManager.XmlFilePath, ":ro");
         addFilesystemPerm(PathManager.RiivolutionWhWzFolderPath, ":ro");
         // Read-write permissions
-        if (!PathManager.LinuxDolphinFlatpakDataDir.Equals(PathManager.UserFolderPath, StringComparison.Ordinal))
+        if (!PathManager.LinuxDolphinFlatpakDataDir.Equals(Path.GetFullPath(PathManager.UserFolderPath), StringComparison.Ordinal))
         {
             addFilesystemPerm(PathManager.UserFolderPath, ":rw");
         }

--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -98,7 +98,7 @@ public static class DolphinLaunchHelper
         {
             addFilesystemPerm(PathManager.UserFolderPath, ":rw");
         }
-        addFilesystemPerm(PathManager.SaveFolderPath, ":rw");
+        addFilesystemPerm(PathManager.SaveFolderPath, ":create");
         return fixedFlatpakDolphinLocation;
     }
 


### PR DESCRIPTION
This is a small fix for Flatpak users. If the save folder did not exist yet, the game would not have the permission to the save folder, causing the game to not even load for new users.