### PR TITLE
Fix path escape

### DIFF
--- a/WheelWizard/Views/BehaviorComponent/FeedbackTextBox.axaml.cs
+++ b/WheelWizard/Views/BehaviorComponent/FeedbackTextBox.axaml.cs
@@ -98,10 +98,14 @@ public partial class FeedbackTextBox : UserControl
     
     private void UpdateErrorState(bool hasError)
     {
-        if (hasError && !InputField.Classes.Contains("error"))
-            InputField.Classes.Add("error");
-        else
+        if (!hasError)
+        {
             InputField.Classes.Remove("error");
+            return;
+        }
+        
+        if (!InputField.Classes.Contains("error"))
+            InputField.Classes.Add("error");
     }
     
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)

--- a/WheelWizard/WheelWizard.csproj
+++ b/WheelWizard/WheelWizard.csproj
@@ -11,7 +11,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 
         <!-- Program details -->
-        <Version>2.1.0</Version>
+        <Version>2.1.2</Version>
         <Description>This program will manage RetroRewind and mods :)</Description>
         <Copyright>GNU v3.0</Copyright>
         <RepositoryUrl>https://github.com/patchzyy/WheelWizard</RepositoryUrl>


### PR DESCRIPTION
## Purpose of this PR:
Fix a path escape bug when naming mods

###  How to Test:
call a mod "." it should not let you

### What Has Been Changed:
extra validation


## Checklist before merging
- [x] You have created relevant tests
