### PR TITLE
fix: Improve Flatpak permission handling and use of portals

### DIFF
--- a/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
+++ b/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
@@ -55,6 +55,7 @@
   </provides>
 
   <releases>
+    <release version="2.1.3" date="2025-04-13"/>
     <release version="2.1.0" date="2025-04-11"/>
   </releases>
 

--- a/WheelWizard/WheelWizard.csproj
+++ b/WheelWizard/WheelWizard.csproj
@@ -11,7 +11,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 
         <!-- Program details -->
-        <Version>2.1.2</Version>
+        <Version>2.1.3</Version>
         <Description>This program will manage RetroRewind and mods :)</Description>
         <Copyright>GNU v3.0</Copyright>
         <RepositoryUrl>https://github.com/patchzyy/WheelWizard</RepositoryUrl>


### PR DESCRIPTION
## Purpose of this PR:
Enable Flatpak portal paths as user folders without permission issues. Furthermore, we bump the version number(s) to be able to release this to `flathub` (not just in the `.csproj`).

###  How to Test:
This was tested by using the file picker for the user folder, creating a `/run/user/...` path. Dolphin is granted the necessary permissions and Wheel Wizard is also able to work with that folder.

### What Has Been Changed:
The Flatpak Dolphin permission fixing logic. We try to fix portal paths where applicable, not just for the game file. This should still work if we made `RiivolutionWhWzFolderPath` configurable in the GUI in the future.

### Related Issue Link:
#88

## Checklist before merging
- [X] You have created relevant tests
