### PR TITLE
feat: mac topbar

### DIFF
--- a/WheelWizard/Views/Layout.axaml
+++ b/WheelWizard/Views/Layout.axaml
@@ -9,9 +9,10 @@
         xmlns:settings="clr-namespace:WheelWizard.Views.Pages.Settings"
         xmlns:components="clr-namespace:WheelWizard.Views.Components"
         Height="876" Width="656" WindowStartupLocation="CenterScreen"
-        SystemDecorations="None"
+        SystemDecorations="Full"
         ExtendClientAreaToDecorationsHint="True"
-        ExtendClientAreaChromeHints="NoChrome" 
+        ExtendClientAreaChromeHints="PreferSystemChrome"
+        ExtendClientAreaTitleBarHeightHint="0"
         CanResize='False' Background="Transparent">
     <Grid ColumnDefinitions="192,*" RowDefinitions="25,17,88,*,80" x:Name="CompleteGrid"
           Background="{StaticResource FrameColor}">

--- a/WheelWizard/Views/Layout.axaml
+++ b/WheelWizard/Views/Layout.axaml
@@ -27,7 +27,8 @@
                 x:Name="DisabledDarkenEffect" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
                 Background="Black"  Opacity="0.3"/> 
         
-        <DockPanel Grid.Row="0" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Top">
+        <DockPanel Grid.Row="0" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Top"
+                   x:Name="TopBarButtons">
             <Button Width="30" Height="25" Click="MinimizeButton_Click"  Classes="TopButton">
                 <PathIcon Data="{StaticResource MinMark}" Width="12" Height="12"
                           Foreground="{Binding $parent[Button].Foreground}" />

--- a/WheelWizard/Views/Layout.axaml
+++ b/WheelWizard/Views/Layout.axaml
@@ -14,7 +14,7 @@
         ExtendClientAreaChromeHints="PreferSystemChrome"
         ExtendClientAreaTitleBarHeightHint="0"
         CanResize='False' Background="Transparent">
-    <Grid ColumnDefinitions="192,*" RowDefinitions="25,17,88,*,80" x:Name="CompleteGrid"
+    <Grid ColumnDefinitions="192,*" RowDefinitions="25,17,18,70,*,80" x:Name="CompleteGrid"
           Background="{StaticResource FrameColor}">
                 
         <Border Grid.ColumnSpan="2"
@@ -39,16 +39,14 @@
             </Button>
         </DockPanel>
         
-        <Border Grid.Column="0" Grid.Row="0" Grid.RowSpan="2" VerticalAlignment="Bottom">
+        <Border Grid.Column="0" Grid.Row="0" Grid.RowSpan="3" VerticalAlignment="Bottom">
             <components:IconLabel IconData="{StaticResource WheelIcon}" x:Name="TitleLabel"
                              Foreground="{StaticResource Neutral400}"
-                             FontSize="20"
-                             Margin="10,10,0,0"
-                             IconSize="31" />
+                             FontSize="20" IconSize="31" 
+                             Margin="10,10,0,18"/>
         </Border>
         
-        <Border Grid.Row="3"
-                VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="10">
+        <Border Grid.Row="4" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="10">
             <StackPanel>
                 <TextBlock Classes="TinyText" x:Name="MadeBy_Part1" Text="Made by: Patchzy" HorizontalAlignment="Right"/>
                 <TextBlock Classes="TinyText" x:Name="MadeBy_Part2" Text="And WantToBeeMe" HorizontalAlignment="Right"/>
@@ -56,13 +54,14 @@
         </Border>
         
 
-        <Border Grid.Column="1" Grid.Row="1" Grid.RowSpan="4"
+        <Border Grid.Column="1" Grid.Row="1" Grid.RowSpan="5"
                 CornerRadius="{StaticResource WindowCornerRadiusLeftRightTwix}"
                 Background="{StaticResource BackgroundColor}"/>
-        <ContentControl Grid.Column="1" Grid.Row="1" Grid.RowSpan="4" ClipToBounds="False"
+        <ContentControl Grid.Column="1" Grid.Row="1" Grid.RowSpan="5" ClipToBounds="False"
                         x:Name="ContentArea" Margin="{StaticResource EdgeGap}"/>
         
-        <StackPanel Grid.Row="2" Orientation="Horizontal" VerticalAlignment="Center">
+        <StackPanel Grid.Row="3" Orientation="Horizontal" VerticalAlignment="Bottom"
+                    Margin="0,0,0,25">
             <components:StateBox x:Name="PlayerCountBox" Text="0" Variant="Dark"
                                   IconData="{StaticResource UserCouple}"
                                   TipText="{x:Static lang:Phrases.Hover_PlayersOnline_0}"
@@ -73,7 +72,7 @@
                             Margin="10,0,0,0" />
         </StackPanel>
         
-        <Border Grid.Column="0" Grid.Row="3" VerticalAlignment="Bottom" HorizontalAlignment="Left"
+        <Border Grid.Column="0" Grid.Row="4" VerticalAlignment="Bottom" HorizontalAlignment="Left"
                 ToolTip.Tip="This only shows regions YOU have played on"
                 ToolTip.Placement="TopEdgeAlignedLeft" ToolTip.ShowDelay="20"
                 x:Name="LiveStatusBorder" IsVisible="False"
@@ -113,8 +112,8 @@
         
         <!-- Sidebar -->
         <TextBlock Text="{x:Static lang:Common.Term_General}" Classes="SidebarSectionText"
-                   VerticalAlignment="Bottom" Grid.Row="2" />
-        <StackPanel x:Name="SidePanelButtons" Grid.Column="0" Grid.Row="3" Width="192" VerticalAlignment="Top">
+                   VerticalAlignment="Bottom" Grid.Row="3" />
+        <StackPanel x:Name="SidePanelButtons" Grid.Column="0" Grid.Row="4" Width="192" VerticalAlignment="Top">
             <components:SidebarRadioButton IconData="{StaticResource Home}"
                                         Text="{x:Static lang:Common.PageTitle_Home}"
                                         PageType="{x:Type pages:HomePage}"
@@ -142,7 +141,7 @@
                                         Text="Kitchen Sink" x:Name="KitchenSinkButton"/>
         </StackPanel>
         
-        <Border Grid.Column="0" Grid.Row="4" Background="{StaticResource Neutral800}">
+        <Border Grid.Column="0" Grid.Row="5" Background="{StaticResource Neutral800}">
             <StackPanel VerticalAlignment="Center" Spacing="5">
                 <components:IconLabelButton IconData="{StaticResource DiscordIcon}"
                                        Text="{x:Static lang:Phrases.Sidebar_Link_Discord}"

--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -53,6 +54,7 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener, ISettingListene
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             TopBarButtons.IsVisible = false;
+            TitleLabel.Margin -= new Thickness(0, 0, 0, 18);
         }
 
         WhWzStatusManager.Instance.Subscribe(this);

--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -50,7 +50,7 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener, ISettingListene
             MadeBy_Part2.Text = split[1];
         }
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || true)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             TopBarButtons.IsVisible = false;
         }

--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -47,6 +48,11 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener, ISettingListene
             var split = completeString.Split("\\n");
             MadeBy_Part1.Text = split[0];
             MadeBy_Part2.Text = split[1];
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || true)
+        {
+            TopBarButtons.IsVisible = false;
         }
 
         WhWzStatusManager.Instance.Subscribe(this);


### PR DESCRIPTION
## Purpose of this PR:
when the OS is mac, the custom minimuse and close button are disabled, and we make sure we use the mac close and minimise button

###  How to Test:
run this on your own OS. and make sure it still looks nice. If you want oyu can also run it on other operating systems

### What Has Been Changed:
- disable and enable the topbar buttons based on the OS. 
- Move the WhWz logo a little dow if its MacOS

### Related Issue Link:
not related

## Checklist before merging
- [X] You have created relevant tests
