### PR TITLE
Endianness fixes

### DIFF
--- a/WheelWizard.Test/Features/MiiDbServiceTest.cs
+++ b/WheelWizard.Test/Features/MiiDbServiceTest.cs
@@ -442,7 +442,7 @@ namespace WheelWizard.Test.Features
 
             // Assert
             Assert.True(result.IsFailure);
-            Assert.Contains("Invalid MiiName", result.Error.Message); // Error from MiiSerializer via GetByClientId
+            Assert.Contains("Mii data is empty.", result.Error.Message);
             _repository.Received(1).GetRawBlockByClientId(targetId);
             _repository.DidNotReceive().UpdateBlockByClientId(Arg.Any<uint>(), Arg.Any<byte[]>());
         }

--- a/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
+++ b/WheelWizard/Features/WiiManagement/GameDataLoaderService.cs
@@ -228,8 +228,8 @@ public class GameDataSingletonService : RepeatedTaskManager, IGameDataSingletonS
         // In Mario Kart Wii's rksys, offset +0x10 => AvatarId, offset +0x14 => ClientId
         // The name is big-endian UTF-16 at offset itself (length 10 chars => 20 bytes).
         var name = BigEndianBinaryReader.GetUtf16String(_saveData, offset, 10);
-        var avatarId = BitConverter.ToUInt32(_saveData, offset + 0x10);
-        var clientId = BitConverter.ToUInt32(_saveData, offset + 0x14);
+        var avatarId = BigEndianBinaryReader.BufferToUint32(_saveData, offset + 0x10);
+        var clientId = BigEndianBinaryReader.BufferToUint32(_saveData, offset + 0x14);
 
         var rawMiiResult = _miiService.GetByClientId(clientId);
         if (rawMiiResult.IsFailure)

--- a/WheelWizard/Features/WiiManagement/MiiRepositoryService.cs
+++ b/WheelWizard/Features/WiiManagement/MiiRepositoryService.cs
@@ -104,7 +104,7 @@ public class MiiRepositoryService(IFileSystem fileSystem) : IMiiRepository
             if (block.Length != MiiLength)
                 continue;
 
-            var thisId = BigEndianBinaryReader.ReadLittleEndianUInt32(block, 0x18);
+            var thisId = BigEndianBinaryReader.BufferToUint32(block, 0x18);
             if (thisId == clientId)
                 return block;
         }
@@ -130,7 +130,7 @@ public class MiiRepositoryService(IFileSystem fileSystem) : IMiiRepository
             if (block.Length != MiiLength)
                 continue;
 
-            var thisId = BigEndianBinaryReader.ReadLittleEndianUInt32(block, 0x18);
+            var thisId = BigEndianBinaryReader.BufferToUint32(block, 0x18);
             if (thisId != clientId)
                 continue;
 

--- a/WheelWizard/Features/WiiManagement/MiiSerializer.cs
+++ b/WheelWizard/Features/WiiManagement/MiiSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using WheelWizard.Services.WiiManagement.SaveData;
 using WheelWizard.WiiManagement.Domain.Mii;
 
 namespace WheelWizard.WiiManagement;
@@ -35,7 +36,7 @@ public static class MiiSerializer
         data[0x17] = mii.Weight.Value;
 
         // Mii ID (0x18 - 0x1B)
-        BitConverter.GetBytes(mii.MiiId).CopyTo(data, 0x18);
+        BigEndianBinaryReader.WriteUInt32BigEndian(data, 0x18, mii.MiiId);
 
         // System ID (0x1C - 0x1F)
         data[0x1C] = mii.SystemId0;
@@ -143,8 +144,8 @@ public static class MiiSerializer
         if (data == null || data.Length != 74)
             return Fail<Mii>("Invalid Mii data length.");
 
-        //if the data only contains 0xFF, return null
-        if (data.All(b => b == 0xFF))
+        //if the data only contains 0xFF or 0x00, return null
+        if (data.All(b => b == 0xFF) || data.All(b => b == 0x00))
             return Fail<Mii>("Mii data is empty.");
 
         var mii = new Mii();
@@ -174,7 +175,7 @@ public static class MiiSerializer
         mii.Weight = MiiScale.Create(data[0x17]).Value;
 
         // Mii ID (0x18 - 0x1B)
-        mii.MiiId = BitConverter.ToUInt32(data, 0x18);
+        mii.MiiId = BigEndianBinaryReader.BufferToUint32(data, 0x18);
 
         // System ID (0x1C - 0x1F)
         mii.SystemId0 = data[0x1C];

--- a/WheelWizard/Services/ModManager.cs
+++ b/WheelWizard/Services/ModManager.cs
@@ -198,7 +198,7 @@ public class ModManager : INotifyPropertyChanged
         if (newName.IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
             return Fail("Mod name contains illegal characters.");
 
-        if (newName.Any(x=> _illegalChars.Contains(x)))
+        if (newName.Any(x => _illegalChars.Contains(x)))
             return Fail("Mod name contains illegal characters.");
 
         return Ok();

--- a/WheelWizard/Views/BehaviorComponent/FeedbackTextBox.axaml.cs
+++ b/WheelWizard/Views/BehaviorComponent/FeedbackTextBox.axaml.cs
@@ -107,7 +107,7 @@ public partial class FeedbackTextBox : UserControl
             InputField.Classes.Remove("error");
             return;
         }
-        
+
         if (!InputField.Classes.Contains("error"))
             InputField.Classes.Add("error");
     }


### PR DESCRIPTION
## Purpose of this PR:

###  How to Test:
Run tests, they should all pass.

### What Has Been Changed:
Since the beginning of wheel wizard, ID's have been read like little endian,
Mii ID's are stored in Big endian, but code was reading it as little endian, this was not "bad".
But if we want correctness this is the correct way of parsing it

