### PR TITLE
fix: Patch Retro Rewind update process for relative user folders

### DIFF
--- a/WheelWizard/Services/Installation/RetroRewindUpdater.cs
+++ b/WheelWizard/Services/Installation/RetroRewindUpdater.cs
@@ -102,12 +102,13 @@ public static class RetroRewindUpdater
 
             foreach (var file in deletionsToApply)
             {
-                var filePath = Path.GetFullPath(Path.Combine(PathManager.RiivolutionWhWzFolderPath, file.Path.TrimStart('/')));
+                var absoluteDestinationPath = Path.GetFullPath(PathManager.RiivolutionWhWzFolderPath);
+                var filePath = Path.GetFullPath(Path.Combine(absoluteDestinationPath, file.Path.TrimStart('/')));
                 //because we are actually getting the path from the server,
                 //we need to make sure we are not getting hacked, so we check if the path is in the riivolution folder
                 var resolvedPath = Path.GetFullPath(new FileInfo(filePath).FullName);
-                if (!resolvedPath.StartsWith(PathManager.RiivolutionWhWzFolderPath, StringComparison.OrdinalIgnoreCase) ||
-                    !filePath.StartsWith(PathManager.RiivolutionWhWzFolderPath, StringComparison.OrdinalIgnoreCase) ||
+                if (!resolvedPath.StartsWith(absoluteDestinationPath, StringComparison.Ordinal) ||
+                    !filePath.StartsWith(absoluteDestinationPath, StringComparison.Ordinal) ||
                     filePath.Contains(".."))
                 {
                     AbortingUpdate("Invalid file path detected. Please contact the developers.\n Server error: " + resolvedPath);

--- a/WheelWizard/Services/Installation/RetroRewindUpdater.cs
+++ b/WheelWizard/Services/Installation/RetroRewindUpdater.cs
@@ -109,7 +109,7 @@ public static class RetroRewindUpdater
                 var resolvedPath = Path.GetFullPath(new FileInfo(filePath).FullName);
                 if (!resolvedPath.StartsWith(absoluteDestinationPath, StringComparison.Ordinal) ||
                     !filePath.StartsWith(absoluteDestinationPath, StringComparison.Ordinal) ||
-                    filePath.Contains(".."))
+                    file.Path.Contains(".."))
                 {
                     AbortingUpdate("Invalid file path detected. Please contact the developers.\n Server error: " + resolvedPath);
                     return false;


### PR DESCRIPTION
## Purpose of this PR:
Currently, the Retro Rewind update process gets terminated with relative user folders due to the way the `ApplyFileDeletionsBetweenVersions` method is written. Absolute paths are compared to potentially relative `PathManager.RiivolutionWhWzFolderPath` paths. The obvious fix would be to also use an absolute `PathManager.RiivolutionWhWzFolderPath` in this method.

###  How to Test:
Use a relative user folder. Without this patch it should fail with the "Invalid file path detected" message due to the fact that the `StartsWith` calls can never be `true`. With this patch, applying the file deletions should work even with relative user folder configurations.

### What Has Been Changed:
Fix the checks aborting the update if directory traversal is detected.

### Related Issue Link:
#140

## Checklist before merging
- [X] You have created relevant tests
