### PR TITLE
fix: Add missing directory separator to required parent directory

### DIFF
--- a/WheelWizard/Services/Installation/RetroRewindUpdater.cs
+++ b/WheelWizard/Services/Installation/RetroRewindUpdater.cs
@@ -102,7 +102,7 @@ public static class RetroRewindUpdater
 
             foreach (var file in deletionsToApply)
             {
-                var absoluteDestinationPath = Path.GetFullPath(PathManager.RiivolutionWhWzFolderPath);
+                var absoluteDestinationPath = Path.GetFullPath(PathManager.RiivolutionWhWzFolderPath + Path.AltDirectorySeparatorChar);
                 var filePath = Path.GetFullPath(Path.Combine(absoluteDestinationPath, file.Path.TrimStart('/')));
                 //because we are actually getting the path from the server,
                 //we need to make sure we are not getting hacked, so we check if the path is in the riivolution folder


### PR DESCRIPTION
## Purpose of this PR:
Fix the check of the parent directory of files to delete to include the directory separator in order to prevent matching directories with a longer name but the same prefix (just like `ExtractZipFile` does it).

###  How to Test:
Same as #141

### What Has Been Changed:
The destination directory that is supposed to be at the start of the files to delete additionally contains the path separator at the end now.

### Related PR:
#141

## Checklist before merging
- [X] You have created relevant tests
