### PR TITLE
fix: Properly quote paths in commands [needs additional cross-platform testing]

### DIFF
--- a/WheelWizard.Test/Features/GameBananaTests.cs
+++ b/WheelWizard.Test/Features/GameBananaTests.cs
@@ -213,7 +213,7 @@ namespace WheelWizard.Test.Features
                     IconUrl = "",
                 },
                 ModelName = "Mod",
-                PreviewMedia = new()
+                PreviewMedia = new(),
             };
         }
 

--- a/WheelWizard/Features/AutoUpdating/AutoUpdatingExtensions.cs
+++ b/WheelWizard/Features/AutoUpdating/AutoUpdatingExtensions.cs
@@ -13,7 +13,7 @@ public static class AutoUpdatingExtensions
         implementationType = typeof(WindowsUpdatePlatform);
 #elif LINUX
         // We can enable this again once the auto updater has been fixed and tested
-        // implementationType = typeof(LinuxUpdatePlatform);
+        implementationType = typeof(LinuxUpdatePlatform);
 #elif MACOS
         // MacOS updater
 #endif

--- a/WheelWizard/Features/AutoUpdating/Platforms/.gitattributes
+++ b/WheelWizard/Features/AutoUpdating/Platforms/.gitattributes
@@ -1,0 +1,1 @@
+LinuxUpdatePlatform.cs text eol=lf

--- a/WheelWizard/Features/AutoUpdating/Platforms/LinuxUpdatePlatform.cs
+++ b/WheelWizard/Features/AutoUpdating/Platforms/LinuxUpdatePlatform.cs
@@ -81,7 +81,9 @@ public class LinuxUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
 
             echo 'Replacing old executable...'
             rm -f {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, originalFileName))}
-            mv {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, newFileName))} {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, originalFileName))}
+            mv {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, newFileName))} {EnvHelper.SingleQuotePath(
+                fileSystem.Path.Combine(currentFolder, originalFileName)
+            )}
             chmod +x {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, originalFileName))}
 
             echo 'Starting the updated application...'
@@ -91,7 +93,7 @@ public class LinuxUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             rm -- {EnvHelper.SingleQuotePath(scriptFilePath)}
 
             echo 'Update completed successfully.'
-
+            
             """;
         fileSystem.File.WriteAllText(scriptFilePath, scriptContent);
 

--- a/WheelWizard/Features/AutoUpdating/Platforms/LinuxUpdatePlatform.cs
+++ b/WheelWizard/Features/AutoUpdating/Platforms/LinuxUpdatePlatform.cs
@@ -80,18 +80,18 @@ public class LinuxUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             sleep 1
 
             echo 'Replacing old executable...'
-            rm -f "{fileSystem.Path.Combine(currentFolder, originalFileName)}"
-            mv "{fileSystem.Path.Combine(currentFolder, newFileName)}" "{fileSystem.Path.Combine(currentFolder, originalFileName)}"
-            chmod +x "{fileSystem.Path.Combine(currentFolder, originalFileName)}"
+            rm -f {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, originalFileName))}
+            mv {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, newFileName))} {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, originalFileName))}
+            chmod +x {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, originalFileName))}
 
             echo 'Starting the updated application...'
-            nohup "{fileSystem.Path.Combine(currentFolder, originalFileName)}" > /dev/null 2>&1 &
+            nohup {EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, originalFileName))} > /dev/null 2>&1 &
 
             echo 'Cleaning up...'
-            rm -- "{scriptFilePath}"
+            rm -- {EnvHelper.SingleQuotePath(scriptFilePath)}
 
             echo 'Update completed successfully.'
-            
+
             """;
         fileSystem.File.WriteAllText(scriptFilePath, scriptContent);
 

--- a/WheelWizard/Features/AutoUpdating/Platforms/WindowsUpdatePlatform.cs
+++ b/WheelWizard/Features/AutoUpdating/Platforms/WindowsUpdatePlatform.cs
@@ -173,13 +173,7 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
         var processStartInfo = new ProcessStartInfo
         {
             FileName = "powershell.exe",
-            ArgumentList = {
-                "-NoProfile",
-                "-ExecutionPolicy",
-                "Bypass",
-                "-File",
-                scriptFilePath
-            },
+            ArgumentList = { "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptFilePath },
             CreateNoWindow = false,
             UseShellExecute = false,
             WorkingDirectory = currentFolder,

--- a/WheelWizard/Features/AutoUpdating/Platforms/WindowsUpdatePlatform.cs
+++ b/WheelWizard/Features/AutoUpdating/Platforms/WindowsUpdatePlatform.cs
@@ -117,7 +117,7 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             Write-Output 'Starting update process...'
 
             # Wait for the original application to exit
-            while (Get-Process -Name '{{fileSystem.Path.GetFileNameWithoutExtension(originalFileName)}}' -ErrorAction SilentlyContinue) {
+            while (Get-Process -Name {{EnvHelper.SingleQuotePath(fileSystem.Path.GetFileNameWithoutExtension(originalFileName))}} -ErrorAction SilentlyContinue) {
                 Write-Output 'Waiting for {{originalFileName}} to exit...'
                 Start-Sleep -Seconds 1
             }
@@ -129,7 +129,7 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
 
             while (-not $deleted -and $retryCount -lt $maxRetries) {
                 try {
-                    Remove-Item -Path '{{fileSystem.Path.Combine(currentFolder, originalFileName)}}' -Force -ErrorAction Stop
+                    Remove-Item -Path {{EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, originalFileName))}} -Force -ErrorAction Stop
                     $deleted = $true
                 }
                 catch {
@@ -147,10 +147,10 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
 
             Write-Output 'Renaming new executable...'
             try {
-                Rename-Item -Path '{{fileSystem.Path.Combine(
+                Rename-Item -Path {{EnvHelper.SingleQuotePath(fileSystem.Path.Combine(
                 currentFolder,
                 newFileName
-            )}}' -NewName '{{originalFileName}}' -ErrorAction Stop
+            ))}} -NewName {{EnvHelper.SingleQuotePath(originalFileName)}} -ErrorAction Stop
             }
             catch {
                 Write-Output 'Failed to rename {{newFileName}} to {{originalFileName}}. Update aborted.'
@@ -159,13 +159,13 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
             }
 
             Write-Output 'Starting the updated application...'
-            Start-Process -FilePath '{{fileSystem.Path.Combine(currentFolder, originalFileName)}}'
+            Start-Process -FilePath {{EnvHelper.SingleQuotePath(fileSystem.Path.Combine(currentFolder, originalFileName))}}
 
             Write-Output 'Cleaning up...'
-            Remove-Item -Path '{{scriptFilePath}}' -Force
+            Remove-Item -Path {{EnvHelper.SingleQuotePath(scriptFilePath)}} -Force
 
             Write-Output 'Update completed successfully.'
-            
+
             """;
 
         fileSystem.File.WriteAllText(scriptFilePath, scriptContent);
@@ -173,7 +173,13 @@ public class WindowsUpdatePlatform(IFileSystem fileSystem) : IUpdatePlatform
         var processStartInfo = new ProcessStartInfo
         {
             FileName = "powershell.exe",
-            Arguments = $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptFilePath}\"",
+            ArgumentList = {
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                scriptFilePath
+            },
             CreateNoWindow = false,
             UseShellExecute = false,
             WorkingDirectory = currentFolder,

--- a/WheelWizard/Helpers/EnvHelper.cs
+++ b/WheelWizard/Helpers/EnvHelper.cs
@@ -19,8 +19,8 @@ public static class EnvHelper
             };
 
             using var process = Process.Start(processInfo);
-            process.WaitForExit();
-            return process.ExitCode == 0;
+            process?.WaitForExit();
+            return process?.ExitCode == 0;
         }
         catch
         {
@@ -56,5 +56,25 @@ public static class EnvHelper
     public static string? NullIfRelativeLinuxPath(string path)
     {
         return IsRelativeLinuxPath(path) ? null : path;
+    }
+
+    public static string SingleQuotePath(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // PowerShell expects doubled single quotes inside the quoted string
+            return $"'{path.Replace("'", "''")}'";
+        }
+        return $"'{path.Replace("'", "'\\''")}'";
+    }
+
+    public static string QuotePath(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // Use double quotes outside of PowerShell
+            return $"\"{path}\"";
+        }
+        return SingleQuotePath(path);
     }
 }

--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -91,7 +91,7 @@ public static class DolphinLaunchHelper
             var flatpakRunCommand = "flatpak run";
             fixedFlatpakDolphinLocation = fixedFlatpakDolphinLocation.Replace(
                 flatpakRunCommand,
-                $"{flatpakRunCommand} --filesystem=\"{Path.GetFullPath(newFilesystemPerm)}\"{mode}"
+                $"{flatpakRunCommand} --filesystem={EnvHelper.SingleQuotePath(Path.GetFullPath(newFilesystemPerm))}{mode}"
             );
         }
 
@@ -127,7 +127,7 @@ public static class DolphinLaunchHelper
             var startInfo = new ProcessStartInfo();
 
             var cannotPassUserFolder = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PathManager.IsLinuxDolphinConfigSplit();
-            var userFolderArgument = cannotPassUserFolder ? "" : $"-u \"{Path.GetFullPath(PathManager.UserFolderPath)}\"";
+            var userFolderArgument = cannotPassUserFolder ? "" : $"-u {EnvHelper.QuotePath(Path.GetFullPath(PathManager.UserFolderPath))}";
             var dolphinLaunchArguments = $"{arguments} {userFolderArgument}";
 
             var dolphinLocation = (string)SettingsManager.DOLPHIN_LOCATION.Get();

--- a/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
@@ -31,6 +31,6 @@ public static class MiiChannelLaunchHelper
         }
 
         if (miiChannelExists)
-            DolphinLaunchHelper.LaunchDolphin($"-b \"{Path.GetFullPath(MiiChannelPath)}\"");
+            DolphinLaunchHelper.LaunchDolphin($"-b {EnvHelper.QuotePath(Path.GetFullPath(MiiChannelPath))}");
     }
 }

--- a/WheelWizard/Services/Launcher/RrLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrLauncher.cs
@@ -39,7 +39,7 @@ public class RrLauncher : ILauncher
             RetroRewindLaunchHelper.GenerateLaunchJson();
             var dolphinLaunchType = (bool)SettingsManager.LAUNCH_WITH_DOLPHIN.Get() ? "" : "-b";
             DolphinLaunchHelper.LaunchDolphin(
-                $"{dolphinLaunchType} -e \"{Path.GetFullPath(RrLaunchJsonFilePath)}\" --config=Dolphin.Core.EnableCheats=False"
+                $"{dolphinLaunchType} -e {EnvHelper.QuotePath(Path.GetFullPath(RrLaunchJsonFilePath))} --config=Dolphin.Core.EnableCheats=False"
             );
         }
         catch (Exception ex)

--- a/WheelWizard/Services/Storage/FilePickerHelper.cs
+++ b/WheelWizard/Services/Storage/FilePickerHelper.cs
@@ -105,23 +105,32 @@ public static class FilePickerHelper
 
     public static void OpenFolderInFileManager(string folderPath)
     {
+        string? openExecutable;
         if (OperatingSystem.IsWindows())
         {
-            Process.Start("explorer.exe", folderPath);
+            openExecutable = "explorer.exe";
         }
         else if (OperatingSystem.IsLinux())
         {
-            Process.Start("xdg-open", folderPath);
+            openExecutable = "xdg-open";
         }
         else if (OperatingSystem.IsMacOS())
         {
-            // Ensures the ~/Library/Application Support/ folder is escaped properly
-            folderPath = $"\"{folderPath}\"";
-            Process.Start("open", folderPath);
+            openExecutable = "open";
         }
         else
         {
             throw new PlatformNotSupportedException("Unsupported operating system.");
         }
+
+        var info = new ProcessStartInfo(openExecutable)
+        {
+            // Ensures the folder path is escaped properly
+            ArgumentList = {
+                folderPath,
+            }
+        };
+
+        Process.Start(info);
     }
 }

--- a/WheelWizard/Services/Storage/FilePickerHelper.cs
+++ b/WheelWizard/Services/Storage/FilePickerHelper.cs
@@ -126,9 +126,7 @@ public static class FilePickerHelper
         var info = new ProcessStartInfo(openExecutable)
         {
             // Ensures the folder path is escaped properly
-            ArgumentList = {
-                folderPath,
-            }
+            ArgumentList = { folderPath },
         };
 
         Process.Start(info);

--- a/WheelWizard/Views/Pages/Settings/WhWzSettings.axaml.cs
+++ b/WheelWizard/Views/Pages/Settings/WhWzSettings.axaml.cs
@@ -69,17 +69,9 @@ public partial class WhWzSettings : UserControl
             DolphinUserPathInput.Text = folderPath;
     }
 
-    private string WrapOnWhiteSpace(string inputText)
+    private void AssignWrappedDolphinExeInput(string inputText)
     {
-        if (inputText.Any(character => Char.IsWhiteSpace(character)))
-            return $"\"{inputText}\"";
-
-        return inputText;
-    }
-
-    private async void AssignWrappedDolphinExeInput(string inputText)
-    {
-        DolphinExeInput.Text = WrapOnWhiteSpace(inputText);
+        DolphinExeInput.Text = EnvHelper.SingleQuotePath(inputText);
     }
 
     private async void DolphinExeBrowse_OnClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Purpose of this PR:
Mitigate potential unintentional command injections in commands using paths dependent on the environment or user input. We now use the right quoting/escaping methods depending on the context (e.g. the OS).

###  How to Test:
Ensure that the auto updater still works correctly on Windows. Also, test the Linux auto updater (comment out the line for that) with the WheelWizard executable in a directory with some special characters (spaces, quotes, ...)  – the script should be able to run without issues. In addition, it should be ensured that spaces or quotes in paths do not affect the program's ability to launch the game or open the folders (e.g. in `explorer.exe`). These changes have been tested on a fixed Flatpak build of Wheel Wizard: https://github.com/matellush/io.github.TeamWheelWizard.WheelWizard/commit/0073dfc89251bf24705528dfb2cbc9304808c9de. The wrappers were missing quotes around the `$@`, which will be fixed in the next `flathub` build. Using the changes of this PR in combination with the Flatpak wrapper fixes, Wheel Wizard has been confirmed to be able to correctly pass the arguments even with spaces, double or single quotes in the paths.

### What Has Been Changed:
The way paths are quoted and escaped. These changes also affect the Windows and Linux auto updaters. Two helper methods have been added for Windows PowerShell path quoting (`SingleQuotePath`) without interpolations and `QuotePath` for the usual double-quoting. Linux and macOS are now using single quotes in their commands to ensure no unintended shell expansions would occur.

### Related Issue Link:
#148

### Discussion Points:
It would be a good idea to re-enable the Linux auto updater after these changes, as it should quote the paths correctly now in the script.

## Checklist before merging
- [ ] You have created relevant tests
