### PR TITLE
fix: Respect Dolphin settings for `Load` and `Wii` folders

### DIFF
--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -136,7 +136,14 @@ public static class PathManager
 
     public static string LoadFolderPath
     {
-        get { return Path.Combine(UserFolderPath, "Load"); }
+        get
+        {
+            if (SettingsManager.LOAD_PATH.IsValid())
+            {
+                return (string)SettingsManager.LOAD_PATH.Get();
+            }
+            return Path.Combine(UserFolderPath, "Load");
+        }
     }
 
     public static string ConfigFolderPath
@@ -163,7 +170,14 @@ public static class PathManager
 
     public static string WiiFolderPath
     {
-        get { return Path.Combine(UserFolderPath, "Wii"); }
+        get
+        {
+            if (SettingsManager.NAND_ROOT_PATH.IsValid())
+            {
+                return (string)SettingsManager.NAND_ROOT_PATH.Get();
+            }
+            return Path.Combine(UserFolderPath, "Wii");
+        }
     }
 
     public static bool IsFlatpakDolphinFilePath(string filePath)

--- a/WheelWizard/Services/Settings/SettingsManager.cs
+++ b/WheelWizard/Services/Settings/SettingsManager.cs
@@ -27,14 +27,6 @@ public class SettingsManager
         // inside the data directory and not use the XDG config directory, leading to two different configs).
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PathManager.IsLinuxDolphinConfigSplit())
         {
-            // Only verify the folders in this situation since Load/Wii and Config are split
-            string[] requiredSubdirectories = [PathManager.LoadFolderPath, PathManager.ConfigFolderPath, PathManager.WiiFolderPath];
-            foreach (string requiredSubdirectory in requiredSubdirectories)
-            {
-                if (!FileHelper.DirectoryExists(requiredSubdirectory))
-                    return false;
-            }
-
             // In this case, Dolphin would use `EMBEDDED_USER_DIR` which is the portable `user` directory
             // in the current directory (the directory of the WheelWizard executable).
             // This means a split dolphin user folder and config cannot work...
@@ -101,17 +93,21 @@ public class SettingsManager
         SettingValues.RrLanguages.ContainsKey((int)(value ?? -1))
     );
     public static Setting REMOVE_BLUR = new WhWzSetting(typeof(bool), "REMOVE_BLUR", true);
-    public static Setting RR_REGION = new WhWzSetting(
-        typeof(MarioKartWiiEnums.Regions),
-        "RR_Region",
-        RRRegionManager.GetValidRegions().First()
-    );
+    public static Setting RR_REGION = new WhWzSetting(typeof(MarioKartWiiEnums.Regions), "RR_Region", MarioKartWiiEnums.Regions.None);
     public static Setting WW_LANGUAGE = new WhWzSetting(typeof(string), "WW_Language", "en").SetValidation(value =>
         SettingValues.WhWzLanguages.ContainsKey((string)value!)
     );
     #endregion
 
     #region Dolphin Settings
+    public static Setting NAND_ROOT_PATH = new DolphinSetting(typeof(string), ("Dolphin.ini", "General", "NANDRootPath"), "").SetValidation(
+        value => Directory.Exists(value as string ?? string.Empty)
+    );
+
+    public static Setting LOAD_PATH = new DolphinSetting(typeof(string), ("Dolphin.ini", "General", "LoadPath"), "").SetValidation(value =>
+        Directory.Exists(value as string ?? string.Empty)
+    );
+
     public static Setting VSYNC = new DolphinSetting(typeof(bool), ("GFX.ini", "Hardware", "VSync"), false);
     public static Setting INTERNAL_RESOLUTION = new DolphinSetting(
         typeof(int),


### PR DESCRIPTION
## Purpose of this PR:
Make Wheel Wizard use the `Load` and `Wii` folders that Dolphin actually uses.

###  How to Test:
Override the default `Load` and `Wii` folder paths using `Dolphin.ini` with the `LoadPath` and `NANDRootPath` settings in `[General]`. The path to the Mii database should follow the new `Wii` path and the path to the game installation or the license should follow the new `Load` folder. Standard configurations without overrides should continue to work.

### What Has Been Changed:
The `LoadFolderPath` and `WiiFolderPath` getters have been changed to prioritize the Dolphin setting if present. For this, two Dolphin settings have been added that are effectively only read from. As the `RR_REGION` default value seems to have been broken anyway, it is set to `None` because it is not possible to determine without first determining the `LoadFolderPath`. The region is still set correctly in another code path. Additionally, the overly strict validation requiring all directories (`Load`, `Config`, `Wii`) to be present for the user folder to be valid was dropped on Linux, as it is not necessary.

### Related Issue Link:
#155

## Checklist before merging
- [ ] You have created relevant tests
