### PR TITLE
feat: Allow `-p` option for `flatpak-run(1)` commands

### DIFF
--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -180,6 +180,9 @@ public static class PathManager
             $"{flatpakRunCommand} {dolphinAppId}",
             $"{flatpakRunCommand} --system {dolphinAppId}",
             $"{flatpakRunCommand} --user {dolphinAppId}",
+            $"{flatpakRunCommand} -p {dolphinAppId}",
+            $"{flatpakRunCommand} --system -p {dolphinAppId}",
+            $"{flatpakRunCommand} --user -p {dolphinAppId}",
         ];
         foreach (string possibleFlatpakDolphinCommand in possibleFlatpakDolphinCommands)
         {


### PR DESCRIPTION
## Purpose of this PR:
In some cases, the `-p` option for `flatpak run` commands would make sense to specify. The option makes sure that the entire Flatpak sandbox of the Dolphin Flatpak would get killed when the launching parent process dies. Without this option, there can be edge cases where a Dolphin process would remain even after everything else has been killed.

###  How to Test:
Specify any of the newly added command options and make sure the permissions are set correctly for the launched Dolphin process even with the new `-p` flag.

### What Has Been Changed:
The list of known Dolphin Flatpak commands has been extended to account for the `-p` option.

## Checklist before merging
- [X] You have created relevant tests
