### PR TITLE
fix: Correctly update online status of current user profile

### DIFF
--- a/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
+++ b/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
@@ -125,8 +125,6 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
     {
         PrimaryCheckBox.IsChecked = FocussedUser == _currentUserIndex;
         CurrentUserProfile.Classes.Clear();
-        if (currentPlayer?.IsOnline == true)
-            CurrentUserProfile.Classes.Add("Online");
 
         currentPlayer = GameLicenseService.GetUserData(_currentUserIndex);
         ProfileAttribFriendCode.Text = currentPlayer.FriendCode;
@@ -135,6 +133,9 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
         ProfileAttribVr.Text = currentPlayer.Vr.ToString();
         ProfileAttribBr.Text = currentPlayer.Br.ToString();
         CurrentMii = currentPlayer.Mii;
+        IsOnline = currentPlayer.IsOnline;
+        if (IsOnline)
+            CurrentUserProfile.Classes.Add("Online");
 
         ProfileAttribTotalRaces.Text = currentPlayer.TotalRaceCount.ToString();
         ProfileAttribTotalWins.Text = currentPlayer.TotalWinCount.ToString();


### PR DESCRIPTION
## Purpose of this PR:
Fix the issue where the online status is never shown on a license profile, even after switching pages.

###  How to Test:
Get one of your license profiles into a room and check if the online status is updated and the "View Room" button works.

### What Has Been Changed:
The `IsOnline` property is now actually assigned to the `UserProfilePage` from the `currentPlayer`.

### Related Issue Link:
#159

## Checklist before merging
- [ ] You have created relevant tests
