### PR TITLE
fix: Drop incorrect expression in Dolphin location validation

### DIFF
--- a/WheelWizard/Services/Settings/SettingsManager.cs
+++ b/WheelWizard/Services/Settings/SettingsManager.cs
@@ -69,7 +69,7 @@ public class SettingsManager
                     return false;
                 }
             }
-            return FileHelper.FileExists(pathOrCommand) || EnvHelper.IsValidUnixCommand(pathOrCommand);
+            return EnvHelper.IsValidUnixCommand(pathOrCommand);
         }
 
         return FileHelper.FileExists(pathOrCommand);


### PR DESCRIPTION
This is a minor fix for correctness of the validation of Unix commands as the Dolphin location in Wheel Wizard. Since the setting is always interpreted as a shell command, it does not make sense to check for file existence. For example, in the case of a file path with a space and missing quotes around it, `FileHelper.FileExists(pathOrCommand)` would return `true` even if that path would fail when trying to launch Dolphin, since the shell would try to execute the command up until the first space, the rest being arguments.

Both relative paths (dot-relative) and absolute paths will continue to work and validation would still succeed with this change. Note that any executable paths with spaces need to be quoted (or escaped) (which the GUI will do automatically) on Linux or macOS, as one would do it in the shell.