### PR TITLE
fix: Use correct quoting again

### DIFF
--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -91,7 +91,7 @@ public static class DolphinLaunchHelper
             var flatpakRunCommand = "flatpak run";
             fixedFlatpakDolphinLocation = fixedFlatpakDolphinLocation.Replace(
                 flatpakRunCommand,
-                $"{flatpakRunCommand} --filesystem=\"{Path.GetFullPath(newFilesystemPerm)}\"{mode}"
+                $"{flatpakRunCommand} --filesystem={EnvHelper.QuotePath(Path.GetFullPath(newFilesystemPerm))}{mode}"
             );
         }
 


### PR DESCRIPTION
It seems like some conflict might have been resolved in a wrong way – commit b932d4971c719b8982ab192c582aeb5d00a012e0 used the `EnvHelper` method to quote the `--filesystem` argument instead of using double quotes (cf. https://github.com/TeamWheelWizard/WheelWizard/pull/149/commits/b932d4971c719b8982ab192c582aeb5d00a012e0#diff-dc65a8a0511953e6f440b3ecb200a1402532025d9c492f0745c3f2ddb64b33bcL94), but the change seems to be gone. This PR's purpose is to fix it again.