### PR TITLE
fix: initial RetroRewind installation crashes WheelWizard

### DIFF
--- a/WheelWizard/Features/CustomDistributions/IDistribution.cs
+++ b/WheelWizard/Features/CustomDistributions/IDistribution.cs
@@ -19,6 +19,16 @@ public interface IDistribution
     string FolderName { get; }
 
     /// <summary>
+    /// The name of the wiiDisc .xml file in XMLFolderName
+    /// </summary>
+    string XMLFileName { get; }
+
+    /// <summary>
+    /// The name of the folder containing the distributions wiiDisc .xml file
+    /// </summary>
+    string XMLFolderName { get; }
+
+    /// <summary>
     /// Install the distribution.
     /// </summary>
     Task<OperationResult> InstallAsync(ProgressWindow progressWindow);

--- a/WheelWizard/Features/CustomDistributions/RetroRewind.cs
+++ b/WheelWizard/Features/CustomDistributions/RetroRewind.cs
@@ -29,6 +29,8 @@ public class RetroRewind : IDistribution
 
     // Keep in mind, whenever we download update files from the server, they are actually 1 folder higher, so it contains this folder.
     public string FolderName => "RetroRewind6";
+    public string XMLFolderName => "riivolution";
+    public string XMLFileName => "RetroRewind6";
 
     public async Task<OperationResult> InstallAsync(ProgressWindow progressWindow)
     {
@@ -68,8 +70,16 @@ public class RetroRewind : IDistribution
         var tempZipPath = PathManager.RetroRewindTempFile;
         // where we'll do the extraction
         var tempExtractionPath = PathManager.TempModsFolderPath;
-        // where the final RR folder should live
-        var finalDestination = _fileSystem.Path.Combine(PathManager.RiivolutionWhWzFolderPath, FolderName);
+
+        //where all distributions are stored
+        var destinationParentDir = _fileSystem.DirectoryInfo.New(PathManager.RiivolutionWhWzFolderPath);
+
+        //where the RR distribution lives
+        var distributionDataDestination = _fileSystem.Path.Combine(destinationParentDir.FullName, FolderName);
+        //where the RR wiiDisc xml file lives
+        var riivolutionFolderDestination = PathManager.RiivolutionXmlFolderPath;
+        var riivolutionDiscXMLFile = _fileSystem.Path.Combine(riivolutionFolderDestination, $"{XMLFileName}.xml");
+
         Exception? exception = null;
         try
         {
@@ -101,17 +111,34 @@ public class RetroRewind : IDistribution
             }
 
             // 4) Replace existing install, if any
-            if (_fileSystem.Directory.Exists(finalDestination))
-                _fileSystem.Directory.Delete(finalDestination, recursive: true);
+            if (_fileSystem.Directory.Exists(distributionDataDestination))
+                _fileSystem.Directory.Delete(distributionDataDestination, recursive: true);
+            if (_fileSystem.File.Exists(riivolutionDiscXMLFile))
+                _fileSystem.File.Delete(riivolutionDiscXMLFile);
 
-            // 5) Move into place
-            // Make sure the parent directory of 'finalDestination' exists
-            var parentDirectory = _fileSystem.DirectoryInfo.New(finalDestination).Parent;
+            // 5) Make sure the target directory exists
+            var parentDirectory = _fileSystem.DirectoryInfo.New(distributionDataDestination).Parent;
             parentDirectory?.Create();
             if ((!parentDirectory?.Exists) ?? true)
                 throw new DirectoryNotFoundException($"Could not find destination `{parentDirectory?.FullName}`");
 
-            _fileSystem.Directory.Move(sourceFolder, finalDestination);
+            // 5) Move over distribution data
+            _fileSystem.Directory.Move(sourceFolder, distributionDataDestination);
+
+            // 6) Move over 'riivolution/' folder. skip existing files
+            var xmlFolderSource = _fileSystem.Path.Combine(tempExtractionPath, XMLFolderName);
+            foreach (var file in _fileSystem.Directory.EnumerateFiles(xmlFolderSource, "*", SearchOption.AllDirectories))
+            {
+                var destinationPath = _fileSystem.Path.Combine(riivolutionFolderDestination, _fileSystem.Path.GetRelativePath(xmlFolderSource, file));
+                var destinationDirectoryName = _fileSystem.Path.GetDirectoryName(destinationPath);
+                if (destinationDirectoryName != null)
+                {
+                    var directory = _fileSystem.DirectoryInfo.New(destinationDirectoryName);
+                    if (!directory?.Exists ?? false)
+                        directory?.Create();
+                }
+                _fileSystem.File.Move(file, destinationPath, false);
+            }
         }
         catch (Exception e)
         {

--- a/WheelWizard/Features/CustomDistributions/RetroRewind.cs
+++ b/WheelWizard/Features/CustomDistributions/RetroRewind.cs
@@ -105,6 +105,12 @@ public class RetroRewind : IDistribution
                 _fileSystem.Directory.Delete(finalDestination, recursive: true);
 
             // 5) Move into place
+            // Make sure the parent directory of 'finalDestination' exists
+            var parentDirectory = _fileSystem.DirectoryInfo.New(finalDestination).Parent;
+            parentDirectory?.Create();
+            if ((!parentDirectory?.Exists) ?? true)
+                throw new DirectoryNotFoundException($"Could not find destination `{parentDirectory?.FullName}`");
+
             _fileSystem.Directory.Move(sourceFolder, finalDestination);
         }
         finally

--- a/WheelWizard/Features/CustomDistributions/RetroRewind.cs
+++ b/WheelWizard/Features/CustomDistributions/RetroRewind.cs
@@ -70,7 +70,7 @@ public class RetroRewind : IDistribution
         var tempExtractionPath = PathManager.TempModsFolderPath;
         // where the final RR folder should live
         var finalDestination = _fileSystem.Path.Combine(PathManager.RiivolutionWhWzFolderPath, FolderName);
-
+        Exception? exception = null;
         try
         {
             // 1) Download
@@ -113,6 +113,10 @@ public class RetroRewind : IDistribution
 
             _fileSystem.Directory.Move(sourceFolder, finalDestination);
         }
+        catch (Exception e)
+        {
+            exception = e;
+        }
         finally
         {
             if (_fileSystem.File.Exists(tempZipPath))
@@ -121,7 +125,7 @@ public class RetroRewind : IDistribution
             if (_fileSystem.Directory.Exists(tempExtractionPath))
                 _fileSystem.Directory.Delete(tempExtractionPath, recursive: true);
         }
-        return Ok();
+        return exception is null ? Ok() : Fail(exception);
     }
 
     private async Task BackupOldrksys()

--- a/WheelWizard/Services/Launcher/RrLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrLauncher.cs
@@ -66,8 +66,16 @@ public class RrLauncher : ILauncher
     {
         var progressWindow = new ProgressWindow();
         progressWindow.Show();
-        await CustomDistributionSingletonService.RetroRewind.InstallAsync(progressWindow);
+        var installResult = await CustomDistributionSingletonService.RetroRewind.InstallAsync(progressWindow);
         progressWindow.Close();
+        if (installResult.IsFailure)
+        {
+            await new MessageBoxWindow()
+                .SetMessageType(MessageBoxWindow.MessageType.Error)
+                .SetTitleText("Unable to install RetroRewind")
+                .SetInfoText(installResult.Error.Message)
+                .ShowDialog();
+        }
     }
 
     public async Task Update()

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -53,7 +53,8 @@ public static class PathManager
 
     // This is not the folder your save file is located in, but its the folder where every Region folder is, so the save file is in SaveFolderPath/Region
     public static string SaveFolderPath => Path.Combine(RiivolutionWhWzFolderPath, "riivolution", "save", "RetroWFC");
-    public static string XmlFilePath => Path.Combine(RiivolutionWhWzFolderPath, "riivolution", "RetroRewind6.xml");
+    public static string RiivolutionXmlFolderPath => Path.Combine(RiivolutionWhWzFolderPath, "riivolution");
+    public static string XmlFilePath => Path.Combine(RiivolutionXmlFolderPath, "RetroRewind6.xml");
 
     private static string PortableUserFolderPath =>
         Path.Combine(GetDolphinExeDirectory(), RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "user" : "User");


### PR DESCRIPTION
## Purpose of this PR:
this PR fixes the crash when freshly installing RR.

###  How to Test:
1. delete the ``Riivolution`` or ``WheelWizard`` directory of the ``<UserFolderPath>/Load/Riivolution/WheelWizard/`` path.
2. try installing RetroRewind via the GUI

### What Has Been Changed:
inserted a few lines in ``WheelWizard/Features/CustomDistributions/RetroRewind.cs`` before copying the extracted RR files to create the parent directory if necessary.

### Related Issue Link:
https://github.com/TeamWheelWizard/WheelWizard/issues/168

## Checklist before merging
- [X] You have created relevant tests
