### PR TITLE
fix: remove duplicate package ref from WheelWizard.Test.csproj

### DIFF
--- a/WheelWizard.Test/WheelWizard.Test.csproj
+++ b/WheelWizard.Test/WheelWizard.Test.csproj
@@ -23,7 +23,6 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Testably.Abstractions.Testing" Version="4.0.1"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Purpose of this PR:
Removed duplicate package ref to ``Testably.Abstractions.Testing`` from the ``WheelWizard.Test.csproj`` file

###  How to Test:
-not applicable-

### What Has Been Changed:
removed a duplicate ``<PackageReference>`` tag

### Related Issue Link:
https://github.com/TeamWheelWizard/WheelWizard/issues/178

## Checklist before merging
- [X] You have created relevant tests
