### PR TITLE
Linting retro rewind code

### DIFF
--- a/WheelWizard/Features/CustomDistributions/CustomDistributionSingletonService.cs
+++ b/WheelWizard/Features/CustomDistributions/CustomDistributionSingletonService.cs
@@ -1,4 +1,5 @@
 using System.IO.Abstractions;
+using Microsoft.Extensions.Logging;
 using WheelWizard.CustomDistributions.Domain;
 using WheelWizard.Shared.Services;
 
@@ -7,18 +8,20 @@ namespace WheelWizard.CustomDistributions;
 public interface ICustomDistributionSingletonService
 {
     List<IDistribution> GetAllDistributions();
+    
+    // FIXME: Abstract this reference away. A generic Distributions service kinda loses its purpose when you still have to reference a distribution by name (like done here)
+    //  Instead you would want something like DistService.GetCurrentDistro()
+    //  The rest of the application should not have to know what distribution is currently active.
     RetroRewind RetroRewind { get; }
 }
 
 public class CustomDistributionSingletonService : ICustomDistributionSingletonService
 {
-    public IFileSystem FileSystem { get; }
     public RetroRewind RetroRewind { get; }
 
-    public CustomDistributionSingletonService(IFileSystem fileSystem, IApiCaller<IRetroRewindApi> api)
+    public CustomDistributionSingletonService(IFileSystem fileSystem, IApiCaller<IRetroRewindApi> api, ILogger<IDistribution> logger)
     {
-        FileSystem = fileSystem;
-        RetroRewind = new RetroRewind(fileSystem, api);
+        RetroRewind = new RetroRewind(fileSystem, api, logger);
     }
 
     public List<IDistribution> GetAllDistributions()


### PR DESCRIPTION
change the RetroRewind installation a bit

###  How to Test:
Install RR and test if it installs it all correctly/

### What Has Been Changed:
1. Removed the double path concatination (just picked the first one and went with that)
2. Removed the fallback sourceFolder path!! 
   Initially it would search for folder `RetroRewind6`, and if extraction folder was there, but not `RetroRewind6` then it would just pick the first one in that list O_O.  It should not do that and just throw. the zip must always contain this folder, if it doesn't, then the downloaded zip might be corrupted, or who knows... . In any case, there are also more folders, and the zip also contains the folder named `apps` which means that the first folder is not even `RetroRewind6`. And even if it was, ZPL could have added this `apps` folder later without us knowing and then it would also break. So yea, removed that bit.
  3. Added logging for this installation. Just 1 log for now in this downloadExtract method. might add it in the rest of the file later.

**Related Issue Link:** https://github.com/TeamWheelWizard/WheelWizard/issues/181

