### PR TITLE
fix: Always trim strings to validate separately if required

### DIFF
--- a/WheelWizard/Services/ModManager.cs
+++ b/WheelWizard/Services/ModManager.cs
@@ -189,6 +189,7 @@ public class ModManager : INotifyPropertyChanged
     // TODO: Use this validation method when refactoring the ModManager
     public OperationResult ValidateModName(string? oldName, string newName)
     {
+        newName = newName?.Trim();
         if (string.IsNullOrWhiteSpace(newName))
             return Fail("Mod name cannot be empty.");
 

--- a/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
+++ b/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
@@ -285,6 +285,7 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
     // But we as team wheel wizard don't think it makes sense to have a mii name shorter than 3, and so from the UI we don't allow it
     private OperationResult ValidateMiiName(string? oldName, string newName)
     {
+        newName = newName?.Trim();
         if (newName.Length is > 10 or < 3)
             return Fail(Phrases.HelperNote_NameMustBetween);
 

--- a/WheelWizard/Views/Popups/Generic/TextInputWindow.axaml.cs
+++ b/WheelWizard/Views/Popups/Generic/TextInputWindow.axaml.cs
@@ -117,7 +117,7 @@ public partial class TextInputWindow : PopupContent
     // Update the Submit button's IsEnabled property based on input
     private void UpdateSubmitButtonState()
     {
-        var inputText = GetTrimmedTextInput();
+        var inputText = GetInputText();
         var validationResultError = inputValidationFunc?.Invoke(_initialText, inputText!).Error?.Message;
 
         SubmitButton.IsEnabled = validationResultError == null;
@@ -132,12 +132,12 @@ public partial class TextInputWindow : PopupContent
 
     private void SubmitButton_Click(object sender, RoutedEventArgs e)
     {
-        _result = GetTrimmedTextInput();
+        _result = GetInputText();
         _tcs?.TrySetResult(_result); // Set the result of the task
         Close();
     }
 
-    private string? GetTrimmedTextInput() => InputField.Text?.Trim();
+    private string? GetInputText() => InputField.Text;
 
     private void CancelButton_Click(object sender, RoutedEventArgs e) => Close();
 

--- a/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorGeneral.axaml.cs
+++ b/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorGeneral.axaml.cs
@@ -82,6 +82,7 @@ public partial class EditorGeneral : MiiEditorBaseControl
 
     private OperationResult ValidateMiiName(string? _, string newName)
     {
+        newName = newName?.Trim();
         if (newName.Length is > 10 or < 3)
             return Fail(Phrases.HelperNote_NameMustBetween);
 
@@ -90,6 +91,7 @@ public partial class EditorGeneral : MiiEditorBaseControl
 
     private OperationResult ValidateCreatorName(string newName)
     {
+        newName = newName?.Trim();
         if (newName.Length > 10)
             return Fail(Phrases.HelperNote_CreatorNameLess10);
 


### PR DESCRIPTION
## Purpose of this PR:
Fix differences in name validation related to the use of `Trim()` on the validated strings.

###  How to Test:
Check the rename/naming popups for mod names, license names, and also those (including the "complex" popup) of the Mii editor for their behaviors with leading or trailing spaces with respect to the length of given names.

### What Has Been Changed:
Drop `Trim()` from the `TextInputView` – now the validation methods should themselves trim the text for length checks etc.

### Related Issue Link:
No related issue

## Checklist before merging
- [ ] You have created relevant tests
