### PR TITLE
fix: Correct error texts to match the actual check

### DIFF
--- a/WheelWizard/Resources/Languages/Phrases.Designer.cs
+++ b/WheelWizard/Resources/Languages/Phrases.Designer.cs
@@ -159,11 +159,11 @@ namespace WheelWizard.Resources.Languages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Creator name must be less than 10 characters long..
+        ///   Looks up a localized string similar to Creator name must be less than 11 characters long..
         /// </summary>
-        public static string HelperNote_CreatorNameLess10 {
+        public static string HelperNote_CreatorNameLess11 {
             get {
-                return ResourceManager.GetString("HelperNote_CreatorNameLess10", resourceCulture);
+                return ResourceManager.GetString("HelperNote_CreatorNameLess11", resourceCulture);
             }
         }
         

--- a/WheelWizard/Resources/Languages/Phrases.cs.resx
+++ b/WheelWizard/Resources/Languages/Phrases.cs.resx
@@ -90,8 +90,8 @@
     <data name="EmptyContent_NoRooms" xml:space="preserve">
         <value>Možná nemáš připojení k internetu, nebo nikdo nehraje.</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
-        <value>Jméno tvůrce musí být kratší než 10 znaků.</value>
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
+        <value>Jméno tvůrce musí být kratší než 11 znaků.</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">
         <value>Jména musí mít délku 3 až 10 znaků.</value>

--- a/WheelWizard/Resources/Languages/Phrases.de.resx
+++ b/WheelWizard/Resources/Languages/Phrases.de.resx
@@ -235,8 +235,8 @@ Um einem bestimmten Raum beizutreten, musst du entweder über einen Freund treff
     <data name="EmptyContent_NoMiis_Title" xml:space="preserve">
         <value>Noch keine Miis erstellt!</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
-        <value>Name des Ersteller muss weniger als 10 Zeichen lang sein.</value>
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
+        <value>Name des Ersteller muss weniger als 11 Zeichen lang sein.</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">
         <value>Namen müssen zwischen 3 und 10 Zeichen lang sein.</value>

--- a/WheelWizard/Resources/Languages/Phrases.es.resx
+++ b/WheelWizard/Resources/Languages/Phrases.es.resx
@@ -234,8 +234,8 @@
     <data name="EmptyContent_NoMiis_Title" xml:space="preserve">
         <value>No hay Miis todavía!</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
-        <value>El nombre del creador tiene que tener menos de 10 caracteres.</value>
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
+        <value>El nombre del creador tiene que tener menos de 11 caracteres.</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">
         <value>Los nombres tienen que tener entre 3 y 10 caracteres.</value>

--- a/WheelWizard/Resources/Languages/Phrases.fr.resx
+++ b/WheelWizard/Resources/Languages/Phrases.fr.resx
@@ -238,8 +238,8 @@ Voulez-vous réinstaller Retro Rewind ? </value>
     <data name="EmptyContent_NoMiis_Title" xml:space="preserve">
         <value>Aucun Mii!</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
-        <value>Le nom de l'auteur doit faire moins de 10 caractères.</value>
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
+        <value>Le nom de l'auteur doit faire moins de 11 caractères.</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">
         <value>Les noms doivent être composés de 3 à 10 caractères.</value>

--- a/WheelWizard/Resources/Languages/Phrases.it.resx
+++ b/WheelWizard/Resources/Languages/Phrases.it.resx
@@ -236,7 +236,7 @@ Vuoi svuotare la tua cartella My-Stuff?</value>
     <data name="EmptyContent_NoMiis_Title" xml:space="preserve">
         <value>Ancora nessun Mii!</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
         <value>Il nome dell'autore deve essere lungo al massimo 10 caratteri.</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">

--- a/WheelWizard/Resources/Languages/Phrases.ja.resx
+++ b/WheelWizard/Resources/Languages/Phrases.ja.resx
@@ -240,7 +240,7 @@ My Stuffフォルダーをクリアしますか？</value>
     <data name="EmptyContent_NoMiis_Title" xml:space="preserve">
         <value>まだMiiがありません！</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
         <value>作成者の名前の長さは10文字以下にしてください</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">

--- a/WheelWizard/Resources/Languages/Phrases.ko.resx
+++ b/WheelWizard/Resources/Languages/Phrases.ko.resx
@@ -235,7 +235,7 @@
     <data name="EmptyContent_NoMiis_Title" xml:space="preserve">
         <value>아직 Mii가 없어요!</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
         <value>작성자 이름은 반드시 10자 이내여야 합니다.</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">

--- a/WheelWizard/Resources/Languages/Phrases.nl.resx
+++ b/WheelWizard/Resources/Languages/Phrases.nl.resx
@@ -358,8 +358,8 @@ Om aan een specifieke kamer deel te nemen, moet je dit óf via een vriend óf vi
     <data name="SnackbarSuccess_ProfileSetPrimary" xml:space="preserve">
         <value>Profiel als hoofdprofiel geselecteerd.</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
-        <value>Naam moet korter dan 10 tekens zijn.</value>
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
+        <value>Naam moet korter dan 11 tekens zijn.</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">
         <value>Naam moet tussen de 3 en 10 tekens lang zijn.</value>

--- a/WheelWizard/Resources/Languages/Phrases.resx
+++ b/WheelWizard/Resources/Languages/Phrases.resx
@@ -375,8 +375,8 @@ To join a specific room, you'll need to either join through a friend, or hope to
     <data name="HelperNote_NameMustBetween" xml:space="preserve">
         <value>Names must be between 3 and 10 characters long.</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
-        <value>Creator name must be less than 10 characters long.</value>
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
+        <value>Creator name must be less than 11 characters long.</value>
     </data>
     <data name="MessageError_FailedChangeName_Title" xml:space="preserve">
         <value>Failed to change name</value>

--- a/WheelWizard/Resources/Languages/Phrases.ru.resx
+++ b/WheelWizard/Resources/Languages/Phrases.ru.resx
@@ -288,8 +288,8 @@
     <data name="EmptyContent_NoModSelected" xml:space="preserve">
         <value>Выберите мод из списка, чтобы узнать подробности.</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
-        <value>Имя создателя должно быть длиной в меньше 10 символов.</value>
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
+        <value>Имя создателя должно быть длиной в меньше 11 символов.</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">
         <value>Имена должны быть длиной от 3 до 10 символов.</value>

--- a/WheelWizard/Resources/Languages/Phrases.tr.resx
+++ b/WheelWizard/Resources/Languages/Phrases.tr.resx
@@ -235,8 +235,8 @@ Belirli bir odaya katılmak için bir arkadaşınız aracılığıyla katılman�
     <data name="EmptyContent_NoMiis_Title" xml:space="preserve">
         <value>Şimdilik Mii yok!</value>
     </data>
-    <data name="HelperNote_CreatorNameLess10" xml:space="preserve">
-        <value>Yapımcı adı 10 karakterden kısa olması gerekiyor.</value>
+    <data name="HelperNote_CreatorNameLess11" xml:space="preserve">
+        <value>Yapımcı adı 11 karakterden kısa olması gerekiyor.</value>
     </data>
     <data name="HelperNote_NameMustBetween" xml:space="preserve">
         <value>Adın 3 ile 10 karakter arasında olması gerekiyor.</value>

--- a/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorGeneral.axaml.cs
+++ b/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorGeneral.axaml.cs
@@ -91,7 +91,7 @@ public partial class EditorGeneral : MiiEditorBaseControl
     private OperationResult ValidateCreatorName(string newName)
     {
         if (newName.Length > 10)
-            return Fail(Phrases.HelperNote_CreatorNameLess10);
+            return Fail(Phrases.HelperNote_CreatorNameLess11);
 
         return Ok();
     }


### PR DESCRIPTION
## Purpose of this PR:
The error text for the creator name in the Mii editor for lengths > 10 does not correspond to the actual check in most languages. This PR is supposed to fix this issue, changing the limit depending on the meaning.

###  How to Test:
Not applicable.

### What Has Been Changed:
The English version will now say "less than 11", since 10 is an allowed value. Languages other than Japanese, Korean and Italian also had to be adapted, but these 3 languages seem to have had the right limit.

### Related Issue Link:
No related issue.

## Checklist before merging
- [ ] You have created relevant tests
