### PR TITLE
fix: Migrate RWFC update endpoint from HTTP to HTTPS

### DIFF
--- a/WheelWizard/Features/CustomDistributions/Domain/RetroRewindApi.cs
+++ b/WheelWizard/Features/CustomDistributions/Domain/RetroRewindApi.cs
@@ -4,7 +4,7 @@ namespace WheelWizard.CustomDistributions.Domain;
 
 public interface IRetroRewindApi
 {
-    [Get("/RetroRewind/RetroRewind.zip")]
+    [Get("/RetroRewind/zip/RetroRewind.zip")]
     Task<HttpContent> DownloadRetroRewindZip();
 
     [Get("/RetroRewind/RetroRewindVersion.txt")]

--- a/WheelWizard/Features/CustomDistributions/RetroRewind.cs
+++ b/WheelWizard/Features/CustomDistributions/RetroRewind.cs
@@ -482,13 +482,15 @@ public class RetroRewind : IDistribution
             var description = parts[3].Trim();
             if (string.IsNullOrWhiteSpace(version) || string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(path))
                 continue;
+            // Fix old URLs using HTTP to the new endpoint
+            var fixedUrl = url.Replace(Endpoints.OldRRUrl, Endpoints.RRUrl);
             if (!SemVersion.TryParse(version, out var _))
                 continue;
             var parsedVersion = SemVersion.Parse(version);
             var updateData = new UpdateData
             {
                 Version = parsedVersion,
-                Url = url,
+                Url = fixedUrl,
                 Description = description,
             };
             versions.Add(updateData);

--- a/WheelWizard/Services/Endpoints.cs
+++ b/WheelWizard/Services/Endpoints.cs
@@ -30,7 +30,8 @@ public static class Endpoints
     // TODO: Refactor all the URLs seen below
 
     // Retro Rewind
-    public const string RRUrl = "http://update.rwfc.net:8000/";
+    public const string OldRRUrl = "http://update.rwfc.net:8000/";
+    public const string RRUrl = "https://rwfc.net/updates/";
     public const string RRZipUrl = RRUrl + "RetroRewind/zip/RetroRewind.zip";
     public const string RRVersionUrl = RRUrl + "RetroRewind/RetroRewindVersion.txt";
     public const string RRVersionDeleteUrl = RRUrl + "RetroRewind/RetroRewindDelete.txt";


### PR DESCRIPTION
## Purpose of this PR:
Migrate the endpoint used for pack updates from HTTP to HTTPS.

###  How to Test:
Perform a full reinstall and incremental updates. Both should still work and no insecure HTTP requests should be made for either of them (can be checked with e.g. Wireshark).

### What Has Been Changed:
- The (currently unused) path for the full Retro Rewind zip was fixed in the new `DownloadRetroRewindZip()` API.
- Incremental updates were changed to fix the legacy HTTP url to to the new HTTPS endpoint
- The `RRUrl`  endpoint constant was updated accordingly

### Related Issue Link:


## Checklist before merging
- [ ] You have created relevant tests
