### PR TITLE
fix: Correct capitalization of `RRRating.pul`

### DIFF
--- a/WheelWizard/Features/WiiManagement/GameLicense/GameLicenseService.cs
+++ b/WheelWizard/Features/WiiManagement/GameLicense/GameLicenseService.cs
@@ -204,7 +204,7 @@ public class GameLicenseSingletonService : RepeatedTaskManager, IGameLicenseSing
 
         var statistics = StatisticsSerializer.ParseStatistics(_rksysData, rkpdOffset);
 
-        // Try to read VR/BR from RRrating.pul file
+        // Try to read VR/BR from RRRating.pul file
         var vrFromRksys = BigEndianBinaryHelper.BufferToUint16(_rksysData, rkpdOffset + 0xB0);
         var brFromRksys = BigEndianBinaryHelper.BufferToUint16(_rksysData, rkpdOffset + 0xB2);
         var vr = vrFromRksys;

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -75,7 +75,7 @@ public static class PathManager
     public static string RetroRewindTempFile => Path.Combine(TempModsFolderPath, "RetroRewind.zip");
     public static string WiiDbFolder => Path.Combine(WiiFolderPath, "shared2", "menu", "FaceLib");
     public static string MiiDbFile => Path.Combine(WiiDbFolder, "RFL_DB.dat");
-    public static string RRratingFilePath => Path.Combine(WiiFolderPath, "shared2", "Pulsar", "RetroRewind6", "RRrating.pul");
+    public static string RRratingFilePath => Path.Combine(WiiFolderPath, "shared2", "Pulsar", "RetroRewind6", "RRRating.pul");
 
     #region Wheel Wizard Appdata Override
 

--- a/WheelWizard/Utilities/Generators/RRratingReader.cs
+++ b/WheelWizard/Utilities/Generators/RRratingReader.cs
@@ -5,12 +5,12 @@ namespace WheelWizard.Utilities.Generators;
 public interface IRRratingReader
 {
     /// <summary>
-    /// Reads VR and BR values from RRrating.pul file for a given profile ID.
+    /// Reads VR and BR values from RRRating.pul file for a given profile ID.
     /// </summary>
     (float vr, float br)? ReadRatingFromFile(byte[] fileData, uint profileId);
 
     /// <summary>
-    /// Reads VR and BR values from RRrating.pul file for a given friend code.
+    /// Reads VR and BR values from RRRating.pul file for a given friend code.
     /// </summary>
     (float vr, float br)? ReadRatingFromFileByFriendCode(byte[] fileData, string friendCode);
 }
@@ -25,7 +25,7 @@ public class RRratingReader : IRRratingReader
     private const uint FlagHasData = 0x1;
 
     /// <summary>
-    /// Reads VR and BR values from RRrating.pul file for a given profile ID.
+    /// Reads VR and BR values from RRRating.pul file for a given profile ID.
     /// </summary>
     public (float vr, float br)? ReadRatingFromFile(byte[] fileData, uint profileId)
     {
@@ -63,7 +63,7 @@ public class RRratingReader : IRRratingReader
     }
 
     /// <summary>
-    /// Reads VR and BR values from RRrating.pul file for a given friend code.
+    /// Reads VR and BR values from RRRating.pul file for a given friend code.
     /// </summary>
     public (float vr, float br)? ReadRatingFromFileByFriendCode(byte[] fileData, string friendCode)
     {


### PR DESCRIPTION
Fix the path of `RRRating.pul` for systems with case-sensitive filesystems. Without this change, the new VR/BR values are not shown for any of the 4 licenses.