### PR TITLE
feat: added a potential lifetime option to the vr history graph

### DIFF
--- a/WheelWizard/Views/Components/WhWzLibrary/VrHistoryGraph.axaml.cs
+++ b/WheelWizard/Views/Components/WhWzLibrary/VrHistoryGraph.axaml.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Runtime.InteropServices.JavaScript;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;


### PR DESCRIPTION
## Purpose of this PR:
Suggestion for a potential new option regarding the vr history graph on the profile page

###  How to Test:
Same as before, open profile and change the date on vr history

### What Has Been Changed:
changes to 1 file, all commented and just suggestions

### Related Issue Link:
--

## Checklist before merging
- [X] You have created relevant tests
