### PR TITLE
more flexible status icon

### DIFF
--- a/WheelWizard/Features/WheelWizardData/Domain/WhWzStatus.cs
+++ b/WheelWizard/Features/WheelWizardData/Domain/WhWzStatus.cs
@@ -2,6 +2,20 @@
 
 public class WhWzStatus
 {
-    public required WhWzStatusVariant Variant { get; set; }
+    /// <summary>
+    /// The variant type (used for preset icon styles). Optional if Icon is provided.
+    /// </summary>
+    public WhWzStatusVariant? Variant { get; set; }
+
+    /// <summary>
+    /// Custom SVG path data for the icon. If provided, this takes precedence over Variant.
+    /// </summary>
+    public string? Icon { get; set; }
+
+    /// <summary>
+    /// Custom color for the icon (hex format like "#123456"). Used when Icon is provided.
+    /// </summary>
+    public string? Color { get; set; }
+
     public required string Message { get; set; }
 }


### PR DESCRIPTION
Now status icon can listne to both the following 2 formats:

```json
{
  "variant": "info",
  "message": "Have fun!"
}
```

```json
{
  "icon": "M233.4 105.4c12.5-12.5 32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L256 173.3 86.6 342.6c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3l192-192z",
  "color": "#123456",
  "message": "Have fun!"
}
```