### PR TITLE
fixed VR history component not showing dropdown

### DIFF
--- a/WheelWizard/Views/Components/WhWzLibrary/VrHistoryGraph.axaml
+++ b/WheelWizard/Views/Components/WhWzLibrary/VrHistoryGraph.axaml
@@ -22,7 +22,6 @@
             DataContext="{Binding RelativeSource={RelativeSource AncestorType=components:VrHistoryGraph}}">
         <Grid RowDefinitions="Auto,Auto,*">
             <Grid Grid.Row="0"
-                  IsVisible="{Binding HasData}"
                   ColumnDefinitions="*,*,*"
                   Margin="0,0,0,8">
                 <Border Grid.Column="0" Classes="profileStatCard" Margin="0,0,4,0">
@@ -58,7 +57,6 @@
             </Grid>
 
             <Grid Grid.Row="1"
-                  IsVisible="{Binding HasData}"
                   ColumnDefinitions="*,Auto"
                   Margin="0,0,0,8">
                 <StackPanel Grid.Column="0">
@@ -66,16 +64,13 @@
                     <TextBlock Classes="TinyText" FontSize="11" Text="{Binding DateRangeText}" />
                 </StackPanel>
 
-                <StackPanel  Grid.Column="1" Orientation="Horizontal">
-                    
+                <StackPanel Grid.Column="1" Orientation="Horizontal">
                     <components:LoadingIcon Margin="3,3,6,3" VerticalAlignment="Center" IsVisible="{Binding IsLoading}" Width="18" Height="18" Foreground="{StaticResource Neutral500}" />
-                    <ComboBox
-                              x:Name="HistoryDaysDropdown"
+                    <ComboBox x:Name="HistoryDaysDropdown"
                               MinWidth="145"
                               VerticalAlignment="Top"
                               SelectionChanged="HistoryDaysDropdown_OnSelectionChanged" />
                 </StackPanel>
-               
             </Grid>
 
             <Grid Grid.Row="2"


### PR DESCRIPTION
## Purpose of this PR:
fixed vr dropdown not showing the vr history option when there hasn't been any history in the selected timeframe

###  How to Test:
old version:
1. load up the ui and navigate to the "My profiles" section
2. select an active licence and the "last 7 days" option
3. select a licence that hasnt had any activity in the 7 days, it will not show
new version: it will now show

### What Has Been Changed:
made it possible to change it after the vr history is gone.
old and new version side by side (old left, new right)
<img width="1100" height="740" alt="{CD13C46E-06D3-4AF2-8B71-B24862C661F3}" src="https://github.com/user-attachments/assets/d7abeab4-753f-4426-80a3-a4db0dfac65c" />

### Related Issue Link:
-

## Checklist before merging
- [X] You have created relevant tests
