### PR TITLE
Add Skip option; clear surface on render failure

### DIFF
--- a/WheelWizard/Views/Patterns/MiiImages/Mii3DRender.axaml.cs
+++ b/WheelWizard/Views/Patterns/MiiImages/Mii3DRender.axaml.cs
@@ -272,6 +272,7 @@ public partial class Mii3DRender : BaseMiiImage
 
             if (result.IsFailure)
             {
+                await Dispatcher.UIThread.InvokeAsync(() => ClearSurface(render.Generation), DispatcherPriority.Background);
                 continue;
             }
 

--- a/WheelWizard/Views/Popups/Generic/MiiRenderingSetupPopup.axaml
+++ b/WheelWizard/Views/Popups/Generic/MiiRenderingSetupPopup.axaml
@@ -14,7 +14,7 @@
                    Margin="0,14,0,0"
                    TextWrapping="Wrap"
                    Classes="BodyText"
-                   Text="Wheel Wizard needs one external file to render Miis offline. Download it once and it will be stored in your Wheel Wizard data folder." />
+                   Text="Wheel Wizard can use one external file to render Miis offline in 3D. Download it once and it will be stored in your Wheel Wizard data folder, or skip and continue without 3D Mii rendering." />
 
         <Border Grid.Row="2"
                 Margin="0,18,0,0"
@@ -49,7 +49,7 @@
             <TextBlock Classes="BodyText"
                        TextWrapping="Wrap"
                        Opacity="0.75"
-                       Text="Closing this popup exits Wheel Wizard. The main app will only open after the required Mii rendering file is installed." />
+                       Text="Skip opens Wheel Wizard without offline 3D Mii rendering. Close exits the app." />
             <TextBlock x:Name="ErrorTextBlock"
                        Classes="BodyText"
                        Foreground="{StaticResource Danger400}"
@@ -58,15 +58,20 @@
         </StackPanel>
 
         <UniformGrid Grid.Row="4"
-                     Columns="2"
+                     Columns="3"
                      Margin="0,24,0,0">
             <components:Button x:Name="CloseButton"
                                Margin="0,0,6,0"
                                Variant="Default"
                                Text="Close"
                                Click="CloseButton_OnClick" />
+            <components:Button x:Name="SkipButton"
+                               Margin="0,0,6,0"
+                               Variant="Default"
+                               Text="Skip"
+                               Click="SkipButton_OnClick" />
             <components:Button x:Name="DownloadButton"
-                               Margin="6,0,0,0"
+                               Margin="0,0,0,0"
                                Variant="Primary"
                                Text="Download"
                                Click="DownloadButton_OnClick" />

--- a/WheelWizard/Views/Popups/Generic/MiiRenderingSetupPopup.axaml.cs
+++ b/WheelWizard/Views/Popups/Generic/MiiRenderingSetupPopup.axaml.cs
@@ -12,6 +12,7 @@ public partial class MiiRenderingSetupPopup : PopupContent
     private readonly TaskCompletionSource<bool> _completionSource = new();
     private CancellationTokenSource? _downloadCancellationTokenSource;
     private bool _downloadCompleted;
+    private bool _skipRequested;
 
     [Inject]
     private IMiiRenderingResourceInstaller ResourceInstaller { get; set; } = null!;
@@ -24,7 +25,7 @@ public partial class MiiRenderingSetupPopup : PopupContent
     {
         InitializeComponent();
         PathTextBlock.Text = PathManager.MiiRenderingResourceFilePath;
-        StatusTextBlock.Text = "Download the Mii rendering resource to continue.";
+        StatusTextBlock.Text = "Download the Mii rendering resource to enable offline 3D Mii rendering.";
         ProgressTextBlock.Text = "Ready to install.";
     }
 
@@ -66,7 +67,7 @@ public partial class MiiRenderingSetupPopup : PopupContent
             _downloadCancellationTokenSource = null;
 
             if (!_downloadCompleted)
-                SetBusyState(false, "Download the Mii rendering resource to continue.");
+                SetBusyState(false, "Download the Mii rendering resource to enable offline 3D Mii rendering.");
         }
     }
 
@@ -93,16 +94,27 @@ public partial class MiiRenderingSetupPopup : PopupContent
         Close();
     }
 
+    private void SkipButton_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_downloadCancellationTokenSource != null)
+            return;
+
+        _skipRequested = true;
+        _completionSource.TrySetResult(true);
+        Close();
+    }
+
     protected override void BeforeClose()
     {
         _downloadCancellationTokenSource?.Cancel();
-        _completionSource.TrySetResult(_downloadCompleted);
+        _completionSource.TrySetResult(_downloadCompleted || _skipRequested);
     }
 
     private void SetBusyState(bool busy, string statusText)
     {
         StatusTextBlock.Text = statusText;
         DownloadButton.IsEnabled = !busy;
+        SkipButton.IsEnabled = !busy;
         CloseButton.IsEnabled = true;
         CloseButton.Text = busy ? "Close and Exit" : "Close";
     }
@@ -111,7 +123,7 @@ public partial class MiiRenderingSetupPopup : PopupContent
     {
         ErrorTextBlock.Text = message;
         ErrorTextBlock.IsVisible = true;
-        SetBusyState(false, "Download the Mii rendering resource to continue.");
+        SetBusyState(false, "Download the Mii rendering resource to enable offline 3D Mii rendering.");
     }
 
     private static string FormatMegabytes(long bytes) => $"{bytes / 1024d / 1024d:F2} MB";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Skip" button to the 3D Mii rendering setup popup, allowing users to proceed without downloading offline 3D rendering support.
  * Updated instructions to explain the offline 3D rendering download option and skip functionality.

* **Bug Fixes**
  * Fixed render surface clearing when 3D rendering encounters errors.

* **UI/UX**
  * Adjusted button layout in the 3D Mii rendering setup popup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->