### PR TITLE
added toggle in settings and a launch option to start retro rewind right away

### DIFF
--- a/WheelWizard/Features/Settings/ISettingsServices.cs
+++ b/WheelWizard/Features/Settings/ISettingsServices.cs
@@ -24,6 +24,7 @@ public interface ISettingsProperties
     Setting GAME_LOCATION { get; }
     Setting FORCE_WIIMOTE { get; }
     Setting LAUNCH_WITH_DOLPHIN { get; }
+    Setting LAUNCH_RR_ON_STARTUP { get; }
     Setting PREFERS_MODS_ROW_VIEW { get; }
     Setting FOCUSED_USER { get; }
     Setting ENABLE_ANIMATIONS { get; }

--- a/WheelWizard/Features/Settings/SettingsManager.cs
+++ b/WheelWizard/Features/Settings/SettingsManager.cs
@@ -109,6 +109,7 @@ public class SettingsManager : ISettingsManager
         GAME_LOCATION = RegisterWhWz("GameLocation", "", value => _fileSystem.File.Exists(value as string ?? string.Empty));
         FORCE_WIIMOTE = RegisterWhWz("ForceWiimote", false);
         LAUNCH_WITH_DOLPHIN = RegisterWhWz("LaunchWithDolphin", false);
+        LAUNCH_RR_ON_STARTUP = RegisterWhWz("LaunchRrOnStartup", false);
         PREFERS_MODS_ROW_VIEW = RegisterWhWz("PrefersModsRowView", true);
         FOCUSED_USER = RegisterWhWz("FavoriteUser", 0, value => (int)(value ?? -1) >= 0 && (int)(value ?? -1) < 4);
 
@@ -195,6 +196,7 @@ public class SettingsManager : ISettingsManager
     public Setting GAME_LOCATION { get; }
     public Setting FORCE_WIIMOTE { get; }
     public Setting LAUNCH_WITH_DOLPHIN { get; }
+    public Setting LAUNCH_RR_ON_STARTUP { get; }
     public Setting PREFERS_MODS_ROW_VIEW { get; }
     public Setting FOCUSED_USER { get; }
     public Setting ENABLE_ANIMATIONS { get; }

--- a/WheelWizard/Resources/Languages/Settings.Designer.cs
+++ b/WheelWizard/Resources/Languages/Settings.Designer.cs
@@ -157,6 +157,15 @@ namespace WheelWizard.Resources.Languages {
                 return ResourceManager.GetString("HelperText_LaunchWithDolphin", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Automatically launches Retro Rewind when Wheel Wizard starts.
+        /// </summary>
+        public static string HelperText_LaunchRrOnStartup {
+            get {
+                return ResourceManager.GetString("HelperText_LaunchRrOnStartup", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to You must set these 3 paths before you can start playing Retro Rewind.
@@ -254,6 +263,15 @@ namespace WheelWizard.Resources.Languages {
         public static string Option_LaunchWithDolphin {
             get {
                 return ResourceManager.GetString("Option_LaunchWithDolphin", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Launch Retro Rewind On Startup.
+        /// </summary>
+        public static string Option_LaunchRrOnStartup {
+            get {
+                return ResourceManager.GetString("Option_LaunchRrOnStartup", resourceCulture);
             }
         }
         

--- a/WheelWizard/Resources/Languages/Settings.resx
+++ b/WheelWizard/Resources/Languages/Settings.resx
@@ -32,6 +32,9 @@
     <data name="Option_LaunchWithDolphin" xml:space="preserve">
         <value>Launch Game With Dolphin Window</value>
     </data>
+    <data name="Option_LaunchRrOnStartup" xml:space="preserve">
+        <value>Launch Retro Rewind On Startup</value>
+    </data>
     <data name="Section_Language" xml:space="preserve">
         <value>Language</value>
     </data>
@@ -43,6 +46,9 @@
     </data>
     <data name="HelperText_LaunchWithDolphin" xml:space="preserve">
         <value>Will launch dolphins main window along with the game</value>
+    </data>
+    <data name="HelperText_LaunchRrOnStartup" xml:space="preserve">
+        <value>Automatically launches Retro Rewind when Wheel Wizard starts</value>
     </data>
     <data name="HelperText_ForceDisableWiimote" xml:space="preserve">
         <value>This setting disables Wiimote ingame, but enables it for the Wii channel</value>

--- a/WheelWizard/Views/App.axaml.cs
+++ b/WheelWizard/Views/App.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.Logging;
 using WheelWizard.AutoUpdating;
 using WheelWizard.MiiRendering.Services;
+using WheelWizard.Settings;
 using WheelWizard.Services.Launcher;
 using WheelWizard.Services;
 using WheelWizard.Services.LiveData;
@@ -132,7 +133,9 @@ public class App : Application
             await whWzDataService.LoadBadgesAsync();
             InitializeManagers();
 
-            if (GetStartupLaunchTarget() == StartupLaunchTarget.RetroRewind)
+            var settingsManager = Services.GetRequiredService<ISettingsManager>();
+            var shouldLaunchRrOnStartup = settingsManager.Get<bool>(settingsManager.LAUNCH_RR_ON_STARTUP);
+            if (GetStartupLaunchTarget() == StartupLaunchTarget.RetroRewind || shouldLaunchRrOnStartup)
             {
                 var rrLauncher = Services.GetRequiredService<RrLauncher>();
                 await rrLauncher.Launch();

--- a/WheelWizard/Views/App.axaml.cs
+++ b/WheelWizard/Views/App.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.Logging;
 using WheelWizard.AutoUpdating;
 using WheelWizard.MiiRendering.Services;
+using WheelWizard.Services.Launcher;
 using WheelWizard.Services;
 using WheelWizard.Services.LiveData;
 using WheelWizard.Services.UrlProtocol;
@@ -18,6 +19,12 @@ namespace WheelWizard.Views;
 
 public class App : Application
 {
+    private enum StartupLaunchTarget
+    {
+        None,
+        RetroRewind,
+    }
+
     /// <summary>
     /// Gets the service provider configured for this application.
     /// </summary>
@@ -51,13 +58,64 @@ public class App : Application
         ToolTipBubbleBehavior.Initialize();
     }
 
-    private static void OpenGameBananaModWindow()
+    private static string? GetLaunchProtocolArgument()
     {
         var args = Environment.GetCommandLineArgs();
+        for (var i = 1; i < args.Length; i++)
+        {
+            var argument = args[i];
+            if (argument.StartsWith("wheelwizard://", StringComparison.OrdinalIgnoreCase))
+                return argument;
+        }
+
+        return null;
+    }
+
+    private static StartupLaunchTarget GetStartupLaunchTarget()
+    {
+        var args = Environment.GetCommandLineArgs();
+
+        for (var i = 1; i < args.Length; i++)
+        {
+            var argument = args[i];
+            if (argument.Equals("--launch", StringComparison.OrdinalIgnoreCase) || argument.Equals("-l", StringComparison.OrdinalIgnoreCase))
+            {
+                if (i + 1 >= args.Length)
+                    continue;
+
+                var launchTarget = args[++i];
+                if (launchTarget.Equals("rr", StringComparison.OrdinalIgnoreCase) ||
+                    launchTarget.Equals("retrorewind", StringComparison.OrdinalIgnoreCase) ||
+                    launchTarget.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase))
+                {
+                    return StartupLaunchTarget.RetroRewind;
+                }
+
+                continue;
+            }
+
+            if (!argument.StartsWith("--launch=", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var launchTargetFromEquals = argument["--launch=".Length..].Trim();
+            if (launchTargetFromEquals.Equals("rr", StringComparison.OrdinalIgnoreCase) ||
+                launchTargetFromEquals.Equals("retrorewind", StringComparison.OrdinalIgnoreCase) ||
+                launchTargetFromEquals.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase))
+            {
+                return StartupLaunchTarget.RetroRewind;
+            }
+        }
+
+        return StartupLaunchTarget.None;
+    }
+
+    private static void OpenGameBananaModWindow()
+    {
         ModManager.Instance.ReloadAsync();
-        if (args.Length <= 1)
+        var protocolArgument = GetLaunchProtocolArgument();
+        if (string.IsNullOrWhiteSpace(protocolArgument))
             return;
-        var protocolArgument = args[1];
+
         _ = UrlProtocolManager.ShowPopupForLaunchUrlAsync(protocolArgument);
     }
 
@@ -73,6 +131,12 @@ public class App : Application
             await updateService.CheckForUpdatesAsync();
             await whWzDataService.LoadBadgesAsync();
             InitializeManagers();
+
+            if (GetStartupLaunchTarget() == StartupLaunchTarget.RetroRewind)
+            {
+                var rrLauncher = Services.GetRequiredService<RrLauncher>();
+                await rrLauncher.Launch();
+            }
         }
         catch (Exception e)
         {

--- a/WheelWizard/Views/App.axaml.cs
+++ b/WheelWizard/Views/App.axaml.cs
@@ -110,21 +110,22 @@ public class App : Application
         return StartupLaunchTarget.None;
     }
 
-    private static void OpenGameBananaModWindow()
+    private static bool OpenGameBananaModWindow()
     {
         ModManager.Instance.ReloadAsync();
         var protocolArgument = GetLaunchProtocolArgument();
         if (string.IsNullOrWhiteSpace(protocolArgument))
-            return;
+            return false;
 
         _ = UrlProtocolManager.ShowPopupForLaunchUrlAsync(protocolArgument);
+        return true;
     }
 
     private async void OnInitializedAsync()
     {
         try
         {
-            OpenGameBananaModWindow();
+            var launchedFromProtocol = OpenGameBananaModWindow();
 
             var updateService = Services.GetRequiredService<IAutoUpdaterSingletonService>();
             var whWzDataService = Services.GetRequiredService<IWhWzDataSingletonService>();
@@ -134,8 +135,9 @@ public class App : Application
             InitializeManagers();
 
             var settingsManager = Services.GetRequiredService<ISettingsManager>();
-            var shouldLaunchRrOnStartup = settingsManager.Get<bool>(settingsManager.LAUNCH_RR_ON_STARTUP);
-            if (GetStartupLaunchTarget() == StartupLaunchTarget.RetroRewind || shouldLaunchRrOnStartup)
+            var requestedByCli = GetStartupLaunchTarget() == StartupLaunchTarget.RetroRewind;
+            var shouldLaunchRrOnStartup = !launchedFromProtocol && settingsManager.Get<bool>(settingsManager.LAUNCH_RR_ON_STARTUP);
+            if (requestedByCli || shouldLaunchRrOnStartup)
             {
                 var rrLauncher = Services.GetRequiredService<RrLauncher>();
                 await rrLauncher.Launch();

--- a/WheelWizard/Views/Pages/Settings/OtherSettings.axaml
+++ b/WheelWizard/Views/Pages/Settings/OtherSettings.axaml
@@ -34,6 +34,12 @@
                         <components1:FormFieldLabel Text="{x:Static lang:Settings.Option_LaunchWithDolphin}"
                                                    TipText="{x:Static lang:Settings.HelperText_LaunchWithDolphin}" />
                     </CheckBox>
+                    <CheckBox Margin="0,2" IsChecked="False"
+                              Classes="SwitchDark"
+                              x:Name="LaunchRrOnStartup">
+                        <components1:FormFieldLabel Text="{x:Static lang:Settings.Option_LaunchRrOnStartup}"
+                                                   TipText="{x:Static lang:Settings.HelperText_LaunchRrOnStartup}" />
+                    </CheckBox>
                 </StackPanel>
             </Border>
             

--- a/WheelWizard/Views/Pages/Settings/OtherSettings.axaml.cs
+++ b/WheelWizard/Views/Pages/Settings/OtherSettings.axaml.cs
@@ -31,6 +31,7 @@ public partial class OtherSettings : UserControlBase
         // Attach event handlers after loading settings to avoid unwanted triggers
         DisableForce.IsCheckedChanged += ClickForceWiimote;
         LaunchWithDolphin.IsCheckedChanged += ClickLaunchWithDolphinWindow;
+        LaunchRrOnStartup.IsCheckedChanged += ClickLaunchRrOnStartup;
     }
 
     private void LoadSettings()
@@ -38,6 +39,7 @@ public partial class OtherSettings : UserControlBase
         // Only loads when the settings are not disabled (aka when the paths are set up correctly)
         DisableForce.IsChecked = SettingsService.Get<bool>(SettingsService.FORCE_WIIMOTE);
         LaunchWithDolphin.IsChecked = SettingsService.Get<bool>(SettingsService.LAUNCH_WITH_DOLPHIN);
+        LaunchRrOnStartup.IsChecked = SettingsService.Get<bool>(SettingsService.LAUNCH_RR_ON_STARTUP);
         OpenSaveFolderButton.IsEnabled = Directory.Exists(PathManager.SaveFolderPath);
     }
 
@@ -54,6 +56,11 @@ public partial class OtherSettings : UserControlBase
     private void ClickLaunchWithDolphinWindow(object? sender, RoutedEventArgs e)
     {
         SettingsService.Set(SettingsService.LAUNCH_WITH_DOLPHIN, LaunchWithDolphin.IsChecked == true);
+    }
+
+    private void ClickLaunchRrOnStartup(object? sender, RoutedEventArgs e)
+    {
+        SettingsService.Set(SettingsService.LAUNCH_RR_ON_STARTUP, LaunchRrOnStartup.IsChecked == true);
     }
 
     private async void Reinstall_RetroRewind(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Purpose of this PR:
Adds command-line launch support and settings toggle so WheelWizard can automatically start Retro Rewind at app startup, without needing to click Play in the UI.

<img width="720" height="940" alt="grafik" src="https://github.com/user-attachments/assets/f2860d86-7748-4ba6-bd5d-4a0580f50f02" />


### How to Test:
1. Build/publish WheelWizard for your platform.
2. Run WheelWizard normally (without args) and confirm normal startup behavior is unchanged.
3. Run with launch flag:
- ./WheelWizard --launch rr
- ./WheelWizard --launch=rr
- ./WheelWizard -l rr
4. Navigate to Settings > Other and enable "Launch Retro Rewind on Startup" then restart.

### What Has Been Changed:
1. Added startup launch argument parsing in WheelWizard/Views/App.axaml.cs using a new StartupLaunchTarget enum.
2. Added support for these argument forms:
- --launch rr
- --launch=rr
- -l rr
3. Updated protocol argument detection to scan all command-line args for wheelwizard://... instead of only the first positional argument.
4. Hooked startup launch behavior into app initialization so that when RR is requested, WheelWizard resolves RrLauncher and invokes its existing Launch() flow.
5. New toggle in settings>other to start retro rewind on wheel wizard startup.

I hope you like the change. Now we can start playing rr even faster than before :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application can now be launched via custom URL protocol scheme.
  * Command-line arguments enable direct launch of RetroRewind on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->