### PR TITLE
fix: Also try to fix `RR.json` portal access if folder was changed

### DIFF
--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -116,7 +116,9 @@ public static class DolphinLaunchHelper
 
         if (!TryFixFlatpakPortalAccess(PathManager.GameFilePath, "-r"))
             AddFilesystemPerm(PathManager.GameFilePath, ":ro");
-        AddFilesystemPerm(PathManager.RrLaunchJsonFilePath, ":ro");
+        // We need to provide the directory where the `RR.json` is located in for portal access!
+        if (!TryFixFlatpakPortalAccess(Path.GetDirectoryName(PathManager.RrLaunchJsonFilePath) ?? "", "-r"))
+            AddFilesystemPerm(PathManager.RrLaunchJsonFilePath, ":ro");
 
         return fixedFlatpakDolphinLocation;
     }


### PR DESCRIPTION
This should help resolve the issue where a changed Wheel Wizard config folder would lead to the game not launching on Linux with the Flatpak versions of Dolphin and Wheel Wizard. The launching code did not have the assumption that the config folder would be configurable in the future.

Potentially related issue: #249 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Flatpak integration with improved permission handling for Dolphin launcher support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->