### PR TITLE
Sanitize download filenames and prevent traversal

### DIFF
--- a/WheelWizard/Helpers/DownloadHelper.cs
+++ b/WheelWizard/Helpers/DownloadHelper.cs
@@ -78,8 +78,9 @@ public static class DownloadHelper
 
                         // Check for filename in Content-Disposition or fallback to URL
                         var contentDisposition = response.Content.Headers.ContentDisposition;
-                        var fileName = contentDisposition?.FileName?.Trim('"') ?? Path.GetFileName(new Uri(url).AbsolutePath);
-                        fileName = Path.ChangeExtension(fileName, Path.GetExtension(finalUrl));
+                        var fileName =
+                            contentDisposition?.FileNameStar ?? contentDisposition?.FileName ?? Path.GetFileName(new Uri(url).AbsolutePath);
+                        fileName = GetSafeDownloadFileName(fileName, finalUrl, url);
 
                         // Add extension if missing in file path
                         if (!Path.HasExtension(fileName))
@@ -93,6 +94,7 @@ public static class DownloadHelper
 
                         // Update resolvedFilePath with resolved fileName
                         resolvedFilePath = Path.Combine(directory, fileName);
+                        EnsurePathStaysWithinDirectory(resolvedFilePath, directory);
                     }
 
                     var totalBytes = response.Content.Headers.ContentLength ?? -1;
@@ -198,5 +200,34 @@ public static class DownloadHelper
         {
             progressPopupWindow.SetCancellationTokenSource(null);
         }
+    }
+
+    private static string GetSafeDownloadFileName(string fileName, string finalUrl, string originalUrl)
+    {
+        var trimmedName = fileName.Trim().Trim('"');
+        if (string.IsNullOrWhiteSpace(trimmedName))
+        {
+            trimmedName = Path.GetFileName(new Uri(originalUrl).AbsolutePath);
+        }
+
+        // Only allow a basename from remote input, never a relative or absolute path.
+        var safeFileName = Path.GetFileName(trimmedName.Replace('\\', '/'));
+        if (string.IsNullOrWhiteSpace(safeFileName))
+            throw new InvalidOperationException("The server returned an invalid download filename.");
+
+        var finalExtension = Path.GetExtension(finalUrl);
+        if (!string.IsNullOrWhiteSpace(finalExtension))
+            safeFileName = Path.ChangeExtension(safeFileName, finalExtension);
+
+        return safeFileName;
+    }
+
+    private static void EnsurePathStaysWithinDirectory(string path, string directory)
+    {
+        var normalizedDirectory = Path.GetFullPath(directory + Path.DirectorySeparatorChar);
+        var normalizedPath = Path.GetFullPath(path);
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        if (!normalizedPath.StartsWith(normalizedDirectory, comparison))
+            throw new InvalidOperationException("The download path escaped the target directory.");
     }
 }

--- a/WheelWizard/Services/Installation/ModInstallation.cs
+++ b/WheelWizard/Services/Installation/ModInstallation.cs
@@ -109,6 +109,7 @@ public static class ModInstallation
     public static void ProcessFile(string file, string destinationDirectory, ProgressWindow progressWindow)
     {
         var extension = Path.GetExtension(file).ToLowerInvariant();
+        var normalizedDestinationDirectory = Path.GetFullPath(destinationDirectory + Path.DirectorySeparatorChar);
 
         if (!Directory.Exists(destinationDirectory))
             Directory.CreateDirectory(destinationDirectory);
@@ -144,12 +145,10 @@ public static class ModInstallation
                 );
 
                 var entryDestinationPath = Path.Combine(destinationDirectory, sanitizedKey);
+                var normalizedEntryDestinationPath = Path.GetFullPath(entryDestinationPath);
 
                 // Ensure the entry destination path is within the destination directory
-                if (
-                    !Path.GetFullPath(entryDestinationPath)
-                        .StartsWith(Path.GetFullPath(destinationDirectory), StringComparison.OrdinalIgnoreCase)
-                )
+                if (!normalizedEntryDestinationPath.StartsWith(normalizedDestinationDirectory, StringComparison.OrdinalIgnoreCase))
                 {
                     throw new UnauthorizedAccessException("Entry is attempting to extract outside of the destination directory.");
                 }

--- a/WheelWizard/Views/App.axaml.cs
+++ b/WheelWizard/Views/App.axaml.cs
@@ -5,11 +5,11 @@ using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.Logging;
 using WheelWizard.AutoUpdating;
 using WheelWizard.MiiRendering.Services;
-using WheelWizard.Settings;
-using WheelWizard.Services.Launcher;
 using WheelWizard.Services;
+using WheelWizard.Services.Launcher;
 using WheelWizard.Services.LiveData;
 using WheelWizard.Services.UrlProtocol;
+using WheelWizard.Settings;
 using WheelWizard.Views.Behaviors;
 using WheelWizard.Views.Popups.Generic;
 using WheelWizard.WheelWizardData;
@@ -79,15 +79,19 @@ public class App : Application
         for (var i = 1; i < args.Length; i++)
         {
             var argument = args[i];
-            if (argument.Equals("--launch", StringComparison.OrdinalIgnoreCase) || argument.Equals("-l", StringComparison.OrdinalIgnoreCase))
+            if (
+                argument.Equals("--launch", StringComparison.OrdinalIgnoreCase) || argument.Equals("-l", StringComparison.OrdinalIgnoreCase)
+            )
             {
                 if (i + 1 >= args.Length)
                     continue;
 
                 var launchTarget = args[++i];
-                if (launchTarget.Equals("rr", StringComparison.OrdinalIgnoreCase) ||
-                    launchTarget.Equals("retrorewind", StringComparison.OrdinalIgnoreCase) ||
-                    launchTarget.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase))
+                if (
+                    launchTarget.Equals("rr", StringComparison.OrdinalIgnoreCase)
+                    || launchTarget.Equals("retrorewind", StringComparison.OrdinalIgnoreCase)
+                    || launchTarget.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase)
+                )
                 {
                     return StartupLaunchTarget.RetroRewind;
                 }
@@ -99,9 +103,11 @@ public class App : Application
                 continue;
 
             var launchTargetFromEquals = argument["--launch=".Length..].Trim();
-            if (launchTargetFromEquals.Equals("rr", StringComparison.OrdinalIgnoreCase) ||
-                launchTargetFromEquals.Equals("retrorewind", StringComparison.OrdinalIgnoreCase) ||
-                launchTargetFromEquals.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase))
+            if (
+                launchTargetFromEquals.Equals("rr", StringComparison.OrdinalIgnoreCase)
+                || launchTargetFromEquals.Equals("retrorewind", StringComparison.OrdinalIgnoreCase)
+                || launchTargetFromEquals.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase)
+            )
             {
                 return StartupLaunchTarget.RetroRewind;
             }


### PR DESCRIPTION
Wheel Wizard downloads a mod into its temp folder \CT-MKWII\Mods\Temp\

 But when it decides what filename to save as, it trusts the server’s filename from the HTTP response in WheelWizard/Helpers/DownloadHelper.cs:79. It does:
```
  Path.Combine(tempFolder, attackerChosenFileName)
```
  and never checks that the final path is still inside Mods\Temp.

  So if the attacker makes the filename something like:

  ......\Microsoft\Windows\Start Menu\Programs\Startup\evil.bat

  then Wheel Wizard can end up saving the download here instead:

  C:\Users<user>\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\evil.bat
  
  Then on next windows launch it could launch this file, this is not something we want

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced path traversal protection during file extraction and downloads to prevent unauthorized directory access.
  * Improved download filename resolution with safer validation and sanitization.

* **Refactor**
  * Optimized internal path validation logic for improved performance.
  * Code formatting and organization improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->