### PR TITLE
feat: added match-based X-axis toggle for VR History Graph

### DIFF
--- a/WheelWizard/Views/Patterns/VrHistoryGraph.axaml
+++ b/WheelWizard/Views/Patterns/VrHistoryGraph.axaml
@@ -65,11 +65,18 @@
                     <TextBlock Classes="TinyText" FontSize="11" Text="{Binding DateRangeText}" />
                 </StackPanel>
 
-                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                     <components:LoadingIcon Margin="3,3,6,3" VerticalAlignment="Center" IsVisible="{Binding IsLoading}" Width="18" Height="18" Foreground="{StaticResource Neutral500}" />
+                    
+                    <CheckBox Classes="Switch" 
+                              Content="Matches" 
+                              IsChecked="{Binding UseMatchesAsXAxis}"
+                              FontSize="12"
+                              VerticalAlignment="Center"/>
+
                     <ComboBox x:Name="HistoryDaysDropdown"
                               MinWidth="145"
-                              VerticalAlignment="Top"
+                              VerticalAlignment="Center"
                               SelectionChanged="HistoryDaysDropdown_OnSelectionChanged" />
                 </StackPanel>
             </Grid>

--- a/WheelWizard/Views/Patterns/VrHistoryGraph.axaml.cs
+++ b/WheelWizard/Views/Patterns/VrHistoryGraph.axaml.cs
@@ -36,6 +36,8 @@ public partial class VrHistoryGraph : UserControlBase, INotifyPropertyChanged
     private int _reloadVersion;
     private bool _isInitializingDaysDropdown;
     private int _selectedHistoryDays = DefaultHistoryDays;
+    private bool _useMatchesAsXAxis;
+    private RwfcPlayerVrHistoryResponse? _lastHistoryResponse;
     private Geometry? _graphPath;
     private Geometry? _graphAreaPath;
     private string _graphStartLabel = string.Empty;
@@ -52,6 +54,22 @@ public partial class VrHistoryGraph : UserControlBase, INotifyPropertyChanged
     static VrHistoryGraph()
     {
         FriendCodeProperty.Changed.AddClassHandler<VrHistoryGraph>((graph, _) => graph.TriggerHistoryReload());
+    }
+
+    public bool UseMatchesAsXAxis
+    {
+        get => _useMatchesAsXAxis;
+        set
+        {
+            if (_useMatchesAsXAxis == value)
+                return;
+
+            _useMatchesAsXAxis = value;
+            OnPropertyChanged(nameof(UseMatchesAsXAxis));
+
+            if (_lastHistoryResponse != null)
+                ApplyHistoryData(_lastHistoryResponse, _selectedHistoryDays);
+        }
     }
 
     public string? FriendCode
@@ -372,6 +390,7 @@ public partial class VrHistoryGraph : UserControlBase, INotifyPropertyChanged
 
     private void ApplyHistoryData(RwfcPlayerVrHistoryResponse historyResponse, int days)
     {
+        _lastHistoryResponse = historyResponse;
         EmptyStateText = "No VR history found for this range yet.";
         StartingVr = historyResponse.StartingVr;
         EndingVr = historyResponse.EndingVr;
@@ -408,19 +427,40 @@ public partial class VrHistoryGraph : UserControlBase, INotifyPropertyChanged
 
         GraphMinVrText = minVr.ToString("N0");
         GraphMaxVrText = maxVr.ToString("N0");
-        var labelFormat = days >= 7 ? "MMM d" : "MMM d HH:mm";
-        GraphStartLabel = graphStart.ToLocalTime().ToString(labelFormat);
-        GraphMidLabel = graphStart.AddSeconds(totalSeconds / 2).ToLocalTime().ToString(labelFormat);
-        GraphEndLabel = graphEnd.ToLocalTime().ToString(labelFormat);
+
+        if (UseMatchesAsXAxis)
+        {
+            GraphStartLabel = "Match 1";
+            GraphMidLabel = $"Match {(orderedByDate.Count / 2) + 1}";
+            GraphEndLabel = $"Match {orderedByDate.Count}";
+        }
+        else
+        {
+            var labelFormat = days >= 7 ? "MMM d" : "MMM d HH:mm";
+            GraphStartLabel = graphStart.ToLocalTime().ToString(labelFormat);
+            GraphMidLabel = graphStart.AddSeconds(totalSeconds / 2).ToLocalTime().ToString(labelFormat);
+            GraphEndLabel = graphEnd.ToLocalTime().ToString(labelFormat);
+        }
 
         var points = orderedByDate
-            .Select(entry =>
-            {
-                var seconds = (entry.Date - graphStart).TotalSeconds;
-                var x = seconds / totalSeconds * GraphWidth;
-                var y = GraphHeight - (entry.TotalVr - minVr) / (double)vrRange * GraphHeight;
-                return new Point(x, y);
-            })
+            .Select(
+                (entry, i) =>
+                {
+                    double x;
+                    if (UseMatchesAsXAxis)
+                    {
+                        x = orderedByDate.Count > 1 ? (double)i / (orderedByDate.Count - 1) * GraphWidth : 0;
+                    }
+                    else
+                    {
+                        var seconds = (entry.Date - graphStart).TotalSeconds;
+                        x = seconds / totalSeconds * GraphWidth;
+                    }
+
+                    var y = GraphHeight - (entry.TotalVr - minVr) / (double)vrRange * GraphHeight;
+                    return new Point(x, y);
+                }
+            )
             .ToList();
 
         GraphPath = BuildLineGeometry(points);
@@ -430,6 +470,7 @@ public partial class VrHistoryGraph : UserControlBase, INotifyPropertyChanged
 
     private void ResetGraph()
     {
+        _lastHistoryResponse = null;
         GraphPath = null;
         GraphAreaPath = null;
         GraphStartLabel = string.Empty;


### PR DESCRIPTION
## Purpose of this PR

The VR History graph previously only used time for the X-axis.

This adds a toggle to switch the X-axis to “Matches,” making it easier to see how VR changes per game.

## How to Test

* Go to the VR History section on a player profile
* Find the new “Matches” toggle in the header (next to the date range dropdown) and click it on and off

## What Changed

* Added a switch (CheckBox) to the `VrHistoryGraph.axaml` header
* Updated `ApplyHistoryData` to support both time-based and match-based X-axis
* Switched X-axis labels dynamically between dates and match numbers
* Cached the last response so toggling doesn’t require a new API call

## Related Issue

N/A (feature request)

## Checklist before merging

* [ ] Add relevant tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Matches" toggle to the VR history graph header, allowing users to switch between time-based and match-based X-axis views of their VR performance history.

* **Style**
  * Enhanced header layout with improved spacing and control alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->