### PR TITLE
Add mod storage modes and patch support

### DIFF
--- a/WheelWizard/Features/GameBanana/Domain/GameBananaModPreview.cs
+++ b/WheelWizard/Features/GameBanana/Domain/GameBananaModPreview.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using WheelWizard.Services;
 
 namespace WheelWizard.GameBanana.Domain;
 
@@ -16,7 +17,8 @@ public class GameBananaModPreview
     public required string Version { get; set; }
 
     [JsonPropertyName("_aTags")]
-    public required List<string> Tags { get; set; }
+    [JsonConverter(typeof(GameBananaTagListJsonConverter))]
+    public required List<GameBananaTag> Tags { get; set; }
 
     [JsonPropertyName("_sProfileUrl")]
     public required string ProfileUrl { get; set; }
@@ -52,4 +54,7 @@ public class GameBananaModPreview
     /// </summary>
     [JsonPropertyName("_sModelName")]
     public required string ModelName { get; set; }
+
+    [JsonIgnore]
+    public bool UsesPatches => ModStorageSystemHelper.UsesPatches(Tags);
 }

--- a/WheelWizard/Features/GameBanana/Domain/GameBananaTag.cs
+++ b/WheelWizard/Features/GameBanana/Domain/GameBananaTag.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WheelWizard.GameBanana.Domain;
+
+public class GameBananaTag
+{
+    public string Title { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}
+
+public sealed class GameBananaTagListJsonConverter : JsonConverter<List<GameBananaTag>>
+{
+    public override List<GameBananaTag> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return [];
+
+        if (reader.TokenType != JsonTokenType.StartArray)
+            return []; //maybe throw but now just do this
+
+        var tags = new List<GameBananaTag>();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+                return tags;
+
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.String:
+                    var tagText = reader.GetString() ?? string.Empty;
+                    tags.Add(new() { Title = tagText, Value = tagText });
+                    break;
+                case JsonTokenType.StartObject:
+                    using (var tagDocument = JsonDocument.ParseValue(ref reader))
+                    {
+                        var root = tagDocument.RootElement;
+                        tags.Add(
+                            new()
+                            {
+                                Title = root.TryGetProperty("_sTitle", out var title) ? title.GetString() ?? string.Empty : string.Empty,
+                                Value = root.TryGetProperty("_sValue", out var value) ? value.GetString() ?? string.Empty : string.Empty,
+                            }
+                        );
+                    }
+                    break;
+
+                default:
+                    using (JsonDocument.ParseValue(ref reader)) { }
+                    break;
+            }
+        }
+
+        throw new JsonException("Unexpected end of GameBanana tag payload.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, List<GameBananaTag> value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+
+        foreach (var tag in value)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("_sTitle", tag.Title);
+            writer.WriteString("_sValue", tag.Value);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+}

--- a/WheelWizard/Features/GameBanana/Domain/GameBananaTag.cs
+++ b/WheelWizard/Features/GameBanana/Domain/GameBananaTag.cs
@@ -17,7 +17,7 @@ public sealed class GameBananaTagListJsonConverter : JsonConverter<List<GameBana
             return [];
 
         if (reader.TokenType != JsonTokenType.StartArray)
-            return []; //maybe throw but now just do this
+            throw new JsonException($"Expected StartArray token, but got {reader.TokenType}.");
 
         var tags = new List<GameBananaTag>();
 

--- a/WheelWizard/Features/Settings/ISettingsServices.cs
+++ b/WheelWizard/Features/Settings/ISettingsServices.cs
@@ -26,6 +26,7 @@ public interface ISettingsProperties
     Setting LAUNCH_WITH_DOLPHIN { get; }
     Setting LAUNCH_RR_ON_STARTUP { get; }
     Setting PREFERS_MODS_ROW_VIEW { get; }
+    Setting USE_PATCHES_SYSTEM { get; }
     Setting FOCUSED_USER { get; }
     Setting ENABLE_ANIMATIONS { get; }
     Setting TESTING_MODE_ENABLED { get; }

--- a/WheelWizard/Features/Settings/SettingsManager.cs
+++ b/WheelWizard/Features/Settings/SettingsManager.cs
@@ -111,6 +111,7 @@ public class SettingsManager : ISettingsManager
         LAUNCH_WITH_DOLPHIN = RegisterWhWz("LaunchWithDolphin", false);
         LAUNCH_RR_ON_STARTUP = RegisterWhWz("LaunchRrOnStartup", false);
         PREFERS_MODS_ROW_VIEW = RegisterWhWz("PrefersModsRowView", true);
+        USE_PATCHES_SYSTEM = RegisterWhWz("UsePatchesSystem", false);
         FOCUSED_USER = RegisterWhWz("FavoriteUser", 0, value => (int)(value ?? -1) >= 0 && (int)(value ?? -1) < 4);
 
         ENABLE_ANIMATIONS = RegisterWhWz("EnableAnimations", true);
@@ -198,6 +199,7 @@ public class SettingsManager : ISettingsManager
     public Setting LAUNCH_WITH_DOLPHIN { get; }
     public Setting LAUNCH_RR_ON_STARTUP { get; }
     public Setting PREFERS_MODS_ROW_VIEW { get; }
+    public Setting USE_PATCHES_SYSTEM { get; }
     public Setting FOCUSED_USER { get; }
     public Setting ENABLE_ANIMATIONS { get; }
     public Setting TESTING_MODE_ENABLED { get; }

--- a/WheelWizard/Services/Launcher/Helpers/ModsLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/ModsLaunchHelper.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Threading;
 using WheelWizard.Helpers;
+using WheelWizard.Models.Mods;
 using WheelWizard.Resources.Languages;
 using WheelWizard.Views.Popups.Generic;
 
@@ -7,24 +8,80 @@ namespace WheelWizard.Services.Launcher.Helpers;
 
 public static class ModsLaunchHelper
 {
-    public static readonly string MyStuffFolderPath = PathManager.MyStuffFolderPath;
     public static readonly string ModsFolderPath = PathManager.ModsFolderPath;
-    public static readonly string[] AcceptedModExtensions = ["*.szs", "*.arc", "*.brstm", "*.brsar", "*.thp"];
 
-    public static async Task PrepareModsForLaunch(string? myStuffFolderPath = null)
+    //todo: move this to like an actual static place somewhere that makes more sense.
+    public static readonly string[] AcceptedMyStuffExtensions =
+    [
+        ".bcp",
+        ".szs",
+        ".bdof",
+        ".bfg",
+        ".blight",
+        ".bmg",
+        ".bmm",
+        ".brctr",
+        ".breff",
+        ".breft",
+        ".brfnt",
+        ".brlan",
+        ".brlyt",
+        ".brres",
+        ".brsar",
+        ".brstm",
+        ".bsp",
+        ".bti",
+        ".chr0",
+        ".clr0",
+        ".krm",
+        ".mdl0",
+        ".pat0",
+        ".rkc",
+        ".rkg",
+        ".scn0",
+        ".shp0",
+        ".srt0",
+        ".tex0",
+        ".thp",
+        ".tpl",
+        ".u8",
+        ".yaz0",
+        ".ast",
+        ".bdl",
+        ".bmd",
+        ".bco",
+        ".bol",
+        ".dat",
+        ".rarc",
+        ".ct-def",
+        ".le-def",
+        ".lex",
+        ".lfl",
+        ".lpar",
+        ".lta",
+        ".tplx",
+        ".wbz",
+        ".wlz",
+        ".wu8",
+        ".ybz",
+        ".ylz",
+    ];
+
+    public static async Task PrepareModsForLaunch(string targetFolderPath, string inactiveFolderPath, ModStorageSystem storageSystem)
     {
-        var resolvedMyStuffFolderPath = myStuffFolderPath ?? MyStuffFolderPath;
+        ClearInactiveFolder(inactiveFolderPath);
+
         var mods = ModManager.Instance.Mods.Where(mod => mod.IsEnabled).ToArray();
         if (mods.Length == 0)
         {
-            if (Directory.Exists(resolvedMyStuffFolderPath) && Directory.EnumerateFiles(resolvedMyStuffFolderPath).Any())
+            if (Directory.Exists(targetFolderPath) && Directory.EnumerateFiles(targetFolderPath).Any())
             {
                 var modsFoundQuestion = new YesNoWindow()
                     .SetButtonText(Common.Action_Delete, Common.Action_Keep)
                     .SetMainText(Phrases.Question_LaunchClearModsFound_Title)
-                    .SetExtraText(Phrases.Question_LaunchClearModsFound_Extra);
+                    .SetExtraText(ModStorageSystemHelper.GetClearFolderPrompt(storageSystem));
                 if (await modsFoundQuestion.AwaitAnswer())
-                    Directory.Delete(resolvedMyStuffFolderPath, true);
+                    Directory.Delete(targetFolderPath, true);
 
                 return;
             }
@@ -38,34 +95,23 @@ public static class ModsLaunchHelper
         {
             if (!mod.IsEnabled)
                 continue;
+
             var modFolder = Path.Combine(ModsFolderPath, mod.Title);
-            foreach (var extension in AcceptedModExtensions)
+            if (!Directory.Exists(modFolder))
+                continue;
+
+            foreach (var file in Directory.GetFiles(modFolder, "*", SearchOption.AllDirectories))
             {
-                var files = Directory.GetFiles(modFolder, extension, SearchOption.AllDirectories);
-                foreach (var file in files)
-                {
-                    var relativePath = Path.GetFileName(file);
-                    // Since higher priority mods overwrite lower ones, we can overwrite entries in the dictionary
-                    finalFiles[relativePath] = file;
-                }
+                if (!ShouldCopyFile(mod, file, storageSystem))
+                    continue;
+
+                var relativePath = Path.GetFileName(file);
+                // Since higher priority mods overwrite lower ones, we can overwrite entries in the dictionary
+                finalFiles[relativePath] = file;
             }
         }
 
-        // Get existing files in MyStuff
-        var existingFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (Directory.Exists(resolvedMyStuffFolderPath))
-        {
-            var files = Directory.GetFiles(resolvedMyStuffFolderPath, "*.*", SearchOption.TopDirectoryOnly);
-            foreach (var file in files)
-            {
-                var relativePath = Path.GetFileName(file);
-                existingFiles.Add(relativePath);
-            }
-        }
-        else
-        {
-            Directory.CreateDirectory(resolvedMyStuffFolderPath);
-        }
+        Directory.CreateDirectory(targetFolderPath);
 
         var totalFiles = finalFiles.Count;
         var progressWindow = new ProgressWindow(Phrases.Progress_InstallingMods).SetGoal(
@@ -76,10 +122,10 @@ public static class ModsLaunchHelper
         await Task.Run(() =>
         {
             var processedFiles = 0;
-            // Delete files in MyStuff that are not in finalFiles
-            if (Directory.Exists(resolvedMyStuffFolderPath))
+            // Delete files in the active loose-mod folder that are not in finalFiles
+            if (Directory.Exists(targetFolderPath))
             {
-                var files = Directory.GetFiles(resolvedMyStuffFolderPath, "*.*", SearchOption.TopDirectoryOnly);
+                var files = Directory.GetFiles(targetFolderPath, "*.*", SearchOption.TopDirectoryOnly);
                 foreach (var file in files)
                 {
                     var relativePath = Path.GetFileName(file);
@@ -94,7 +140,7 @@ public static class ModsLaunchHelper
             {
                 var relativePath = kvp.Key;
                 var sourceFile = kvp.Value;
-                var destinationFile = Path.Combine(resolvedMyStuffFolderPath, relativePath);
+                var destinationFile = Path.Combine(targetFolderPath, relativePath);
 
                 processedFiles++;
                 var progress = (int)((processedFiles) / (double)totalFiles * 100);
@@ -130,5 +176,26 @@ public static class ModsLaunchHelper
         });
 
         progressWindow.Close();
+    }
+
+    private static void ClearInactiveFolder(string inactiveFolderPath)
+    {
+        if (!Directory.Exists(inactiveFolderPath))
+            return;
+
+        Directory.Delete(inactiveFolderPath, true);
+    }
+
+    private static bool ShouldCopyFile(Mod mod, string filePath, ModStorageSystem storageSystem)
+    {
+        var modMetadataFile = Path.Combine(ModsFolderPath, mod.Title, $"{mod.Title}.ini");
+        if (Path.GetFullPath(filePath).Equals(Path.GetFullPath(modMetadataFile), StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (storageSystem == ModStorageSystem.Patches)
+            return true;
+
+        var extension = Path.GetExtension(filePath);
+        return AcceptedMyStuffExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/WheelWizard/Services/Launcher/RrBetaLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrBetaLauncher.cs
@@ -31,7 +31,12 @@ public class RrBetaLauncher : ILauncher
             DolphinLaunchHelper.KillDolphin();
             if (WiiMoteSettings.IsForceSettingsEnabled())
                 WiiMoteSettings.DisableVirtualWiiMote();
-            await ModsLaunchHelper.PrepareModsForLaunch(PathManager.RrBetaMyStuffFolderPath);
+            var storageSystem = ModStorageSystemHelper.GetCurrent(_settingsManager);
+            await ModsLaunchHelper.PrepareModsForLaunch(
+                ModStorageSystemHelper.GetTargetFolderPath(storageSystem, isBeta: true),
+                ModStorageSystemHelper.GetInactiveFolderPath(storageSystem, isBeta: true),
+                storageSystem
+            );
             if (!File.Exists(PathManager.GameFilePath))
             {
                 Dispatcher.UIThread.Post(() =>

--- a/WheelWizard/Services/Launcher/RrLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrLauncher.cs
@@ -32,7 +32,12 @@ public class RrLauncher : ILauncher
             DolphinLaunchHelper.KillDolphin();
             if (WiiMoteSettings.IsForceSettingsEnabled())
                 WiiMoteSettings.DisableVirtualWiiMote();
-            await ModsLaunchHelper.PrepareModsForLaunch();
+            var storageSystem = ModStorageSystemHelper.GetCurrent(_settingsManager);
+            await ModsLaunchHelper.PrepareModsForLaunch(
+                ModStorageSystemHelper.GetTargetFolderPath(storageSystem),
+                ModStorageSystemHelper.GetInactiveFolderPath(storageSystem),
+                storageSystem
+            );
             if (!File.Exists(PathManager.GameFilePath))
             {
                 Dispatcher.UIThread.Post(() =>

--- a/WheelWizard/Services/ModStorageSystem.cs
+++ b/WheelWizard/Services/ModStorageSystem.cs
@@ -52,10 +52,9 @@ public static class ModStorageSystemHelper
             return false;
 
         var titleOnly = normalizedTitle.Split(':', 2)[0].Trim();
-        return normalizedTitle is not null
-            && (
-                titleOnly.Equals("patch", StringComparison.OrdinalIgnoreCase)
-                || titleOnly.Equals("patches", StringComparison.OrdinalIgnoreCase)
-            );
+        return (
+            titleOnly.Equals("patch", StringComparison.OrdinalIgnoreCase)
+            || titleOnly.Equals("patches", StringComparison.OrdinalIgnoreCase)
+        );
     }
 }

--- a/WheelWizard/Services/ModStorageSystem.cs
+++ b/WheelWizard/Services/ModStorageSystem.cs
@@ -1,0 +1,61 @@
+using WheelWizard.GameBanana.Domain;
+using WheelWizard.Resources.Languages;
+using WheelWizard.Settings;
+
+namespace WheelWizard.Services;
+
+public enum ModStorageSystem
+{
+    MyStuff,
+    Patches,
+}
+
+public static class ModStorageSystemHelper
+{
+    public static ModStorageSystem GetCurrent(ISettingsManager settingsManager)
+    {
+        return settingsManager.Get<bool>(settingsManager.USE_PATCHES_SYSTEM) ? ModStorageSystem.Patches : ModStorageSystem.MyStuff;
+    }
+
+    public static string GetDisplayName(ModStorageSystem storageSystem) =>
+        storageSystem == ModStorageSystem.Patches ? "Patches" : Common.PageTitle_Mods;
+
+    public static string GetClearFolderPrompt(ModStorageSystem storageSystem)
+    {
+        if (storageSystem == ModStorageSystem.MyStuff)
+            return Phrases.Question_LaunchClearModsFound_Extra;
+
+        //todo: translation lol
+        return "You are about to launch the game without mods. Do you want to clear your Patches folder?";
+    }
+
+    public static string GetTargetFolderPath(ModStorageSystem storageSystem, bool isBeta = false)
+    {
+        if (storageSystem == ModStorageSystem.Patches)
+            return isBeta ? PathManager.RrBetaPatchesFolderPath : PathManager.PatchesFolderPath;
+
+        return isBeta ? PathManager.RrBetaMyStuffFolderPath : PathManager.MyStuffFolderPath;
+    }
+
+    public static string GetInactiveFolderPath(ModStorageSystem storageSystem, bool isBeta = false)
+    {
+        var inactiveStorageSystem = storageSystem == ModStorageSystem.Patches ? ModStorageSystem.MyStuff : ModStorageSystem.Patches;
+        return GetTargetFolderPath(inactiveStorageSystem, isBeta);
+    }
+
+    public static bool UsesPatches(IEnumerable<GameBananaTag>? tags) => tags?.Any(tag => IsPatchesTag(tag.Title)) == true;
+
+    public static bool IsPatchesTag(string? tagTitle)
+    {
+        var normalizedTitle = tagTitle?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedTitle))
+            return false;
+
+        var titleOnly = normalizedTitle.Split(':', 2)[0].Trim();
+        return normalizedTitle is not null
+            && (
+                titleOnly.Equals("patch", StringComparison.OrdinalIgnoreCase)
+                || titleOnly.Equals("patches", StringComparison.OrdinalIgnoreCase)
+            );
+    }
+}

--- a/WheelWizard/Services/ModStorageSystem.cs
+++ b/WheelWizard/Services/ModStorageSystem.cs
@@ -53,8 +53,7 @@ public static class ModStorageSystemHelper
 
         var titleOnly = normalizedTitle.Split(':', 2)[0].Trim();
         return (
-            titleOnly.Equals("patch", StringComparison.OrdinalIgnoreCase)
-            || titleOnly.Equals("patches", StringComparison.OrdinalIgnoreCase)
+            titleOnly.Equals("patch", StringComparison.OrdinalIgnoreCase) || titleOnly.Equals("patches", StringComparison.OrdinalIgnoreCase)
         );
     }
 }

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -500,15 +500,17 @@ public static class PathManager
 
     #endregion
 
-    //In case it is unclear, the mods folder is a folder with mods that are desired to be installed (if enabled)
-    //When launching we want to move the mods from the Mods folder to the MyStuff folder since that is the folder the game uses
-    //Also remember that mods may not be in a subfolder, all mod files must be located in /MyStuff directly
+    // In case it is unclear, the mods folder is a folder with mods that are desired to be installed (if enabled).
+    // When launching we sync those mods into the active loose-mod runtime folder.
+    // The runtime folder is either MyStuff (legacy) or patches, and all files must be located there directly.
 
     // Helper paths for folders used across multiple files
 
     public static string MyStuffFolderPath => Path.Combine(RiivolutionWhWzFolderPath, "RetroRewind6", "MyStuff");
+    public static string PatchesFolderPath => Path.Combine(RiivolutionWhWzFolderPath, "RetroRewind6", "Patches");
     public static string RrBetaFolderPath => Path.Combine(RiivolutionWhWzFolderPath, "RRBeta");
     public static string RrBetaMyStuffFolderPath => Path.Combine(RrBetaFolderPath, "MyStuff");
+    public static string RrBetaPatchesFolderPath => Path.Combine(RrBetaFolderPath, "Patches");
 
     public static string GetModDirectoryPath(string modName) => Path.Combine(ModsFolderPath, modName);
 

--- a/WheelWizard/Views/App.axaml.cs
+++ b/WheelWizard/Views/App.axaml.cs
@@ -5,11 +5,11 @@ using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.Logging;
 using WheelWizard.AutoUpdating;
 using WheelWizard.MiiRendering.Services;
-using WheelWizard.Settings;
-using WheelWizard.Services.Launcher;
 using WheelWizard.Services;
+using WheelWizard.Services.Launcher;
 using WheelWizard.Services.LiveData;
 using WheelWizard.Services.UrlProtocol;
+using WheelWizard.Settings;
 using WheelWizard.Views.Behaviors;
 using WheelWizard.Views.Popups.Generic;
 using WheelWizard.WheelWizardData;
@@ -79,15 +79,19 @@ public class App : Application
         for (var i = 1; i < args.Length; i++)
         {
             var argument = args[i];
-            if (argument.Equals("--launch", StringComparison.OrdinalIgnoreCase) || argument.Equals("-l", StringComparison.OrdinalIgnoreCase))
+            if (
+                argument.Equals("--launch", StringComparison.OrdinalIgnoreCase) || argument.Equals("-l", StringComparison.OrdinalIgnoreCase)
+            )
             {
                 if (i + 1 >= args.Length)
                     continue;
 
                 var launchTarget = args[++i];
-                if (launchTarget.Equals("rr", StringComparison.OrdinalIgnoreCase) ||
-                    launchTarget.Equals("retrorewind", StringComparison.OrdinalIgnoreCase) ||
-                    launchTarget.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase))
+                if (
+                    launchTarget.Equals("rr", StringComparison.OrdinalIgnoreCase)
+                    || launchTarget.Equals("retrorewind", StringComparison.OrdinalIgnoreCase)
+                    || launchTarget.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase)
+                )
                 {
                     return StartupLaunchTarget.RetroRewind;
                 }
@@ -99,9 +103,11 @@ public class App : Application
                 continue;
 
             var launchTargetFromEquals = argument["--launch=".Length..].Trim();
-            if (launchTargetFromEquals.Equals("rr", StringComparison.OrdinalIgnoreCase) ||
-                launchTargetFromEquals.Equals("retrorewind", StringComparison.OrdinalIgnoreCase) ||
-                launchTargetFromEquals.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase))
+            if (
+                launchTargetFromEquals.Equals("rr", StringComparison.OrdinalIgnoreCase)
+                || launchTargetFromEquals.Equals("retrorewind", StringComparison.OrdinalIgnoreCase)
+                || launchTargetFromEquals.Equals("retro-rewind", StringComparison.OrdinalIgnoreCase)
+            )
             {
                 return StartupLaunchTarget.RetroRewind;
             }

--- a/WheelWizard/Views/Layout.axaml
+++ b/WheelWizard/Views/Layout.axaml
@@ -127,7 +127,7 @@
                                            Text="{x:Static lang:Common.PageTitle_MyProfiles}" x:Name="MyProfilesButton" />
             <patterns:SidebarRadioButton IconData="{StaticResource CubesStacked}"
                                            PageType="{x:Type pages:ModsPage}"
-                                           Text="{x:Static lang:Common.PageTitle_Mods}" />
+                                           Text="{x:Static lang:Common.PageTitle_Mods}" x:Name="ModsButton" />
             <patterns:SidebarRadioButton IconData="{StaticResource Shirt}"
                                            PageType="{x:Type pages:MiiListPage}"
                                            Text="{x:Static lang:Common.PageTitle_MyMiis}" />

--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Platform;
 using WheelWizard.Branding;
 using WheelWizard.Helpers;
 using WheelWizard.Resources.Languages;
+using WheelWizard.Services;
 using WheelWizard.Services.LiveData;
 using WheelWizard.Settings;
 using WheelWizard.Settings.Types;
@@ -105,6 +106,7 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
     {
         Title = BrandingService.Branding.DisplayName;
         TitleLabel.Text = BrandingService.Branding.DisplayName;
+        UpdateModsButtonText();
 
         NavigationManager.NavigateTo<HomePage>();
     }
@@ -136,6 +138,15 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
 
         if (setting == SettingsService.TESTING_MODE_ENABLED)
             UpdateTestingButtonVisibility();
+
+        if (setting == SettingsService.USE_PATCHES_SYSTEM)
+            UpdateModsButtonText();
+    }
+
+    private void UpdateModsButtonText()
+    {
+        var storageSystem = ModStorageSystemHelper.GetCurrent(SettingsService);
+        ModsButton.Text = ModStorageSystemHelper.GetDisplayName(storageSystem);
     }
 
     public void NavigateToPage(UserControl page)

--- a/WheelWizard/Views/Pages/ModsPage.axaml
+++ b/WheelWizard/Views/Pages/ModsPage.axaml
@@ -6,7 +6,7 @@
              xmlns:components="clr-namespace:WheelWizard.Views.Components"
              xmlns:patterns="clr-namespace:WheelWizard.Views.Patterns"
              xmlns:pages="clr-namespace:WheelWizard.Views.Pages"
-             mc:Ignorable="d" d:DesignWidth="656" d:DesignHeight="876"
+             mc:Ignorable="d" d:DesignWidth="450" d:DesignHeight="876"
              x:Class="WheelWizard.Views.Pages.ModsPage"
              x:DataType="pages:ModsPage">
     <Grid>
@@ -20,18 +20,21 @@
         <Border Grid.Row="1" Background="{StaticResource BackgroundLineColor}" Height="1"
                 HorizontalAlignment="Stretch" VerticalAlignment="Bottom" />
 
-        <TextBlock Grid.Row="0" Text="{x:Static lang:Common.PageTitle_Mods}"
+        <TextBlock Grid.Row="0" Text="{Binding StoragePageTitle}"
                    HorizontalAlignment="Left" VerticalAlignment="Bottom"
                    Classes="PageTitleText" />
 
         <StackPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10,12"
-                    Orientation="Horizontal" x:Name="TopBarButtons" IsVisible="{Binding HasMods}">
-             <StackPanel Orientation="Horizontal" Spacing="8">
+                    Orientation="Vertical" x:Name="TopBarButtons" Spacing="3">
+            <CheckBox Classes="Switch"
+                      VerticalAlignment="Center"
+                      Content="Use Patches"
+                      IsChecked="{Binding UsePatches, Mode=TwoWay}" />
+            <StackPanel Orientation="Horizontal" Spacing="8" IsVisible="{Binding HasMods}">
                 <components:Button Variant="Primary" 
                                    Text="{x:Static lang:Common.Action_Browse}" IconData="{StaticResource Search}"
                                    Click="BrowseMod_Click" HorizontalAlignment="Center" />
                 <components:Button Variant="Default"
-                                   Text="{x:Static lang:Common.Action_Import}"
                                    IconData="{StaticResource FileImport}"
                                    Click="ImportMod_Click" HorizontalAlignment="Center" />
             </StackPanel>

--- a/WheelWizard/Views/Pages/ModsPage.axaml.cs
+++ b/WheelWizard/Views/Pages/ModsPage.axaml.cs
@@ -21,8 +21,13 @@ public record ModListItem(Mod Mod, bool IsLowest, bool IsHighest);
 
 public partial class ModsPage : UserControlBase, INotifyPropertyChanged
 {
+    private IDisposable? _settingsSignalSubscription;
+
     [Inject]
     private ISettingsManager SettingsService { get; set; } = null!;
+
+    [Inject]
+    private ISettingsSignalBus SettingsSignalBus { get; set; } = null!;
 
     public ModManager ModManager => ModManager.Instance;
 
@@ -34,6 +39,21 @@ public partial class ModsPage : UserControlBase, INotifyPropertyChanged
                 mod.Priority == ModManager.Instance.GetHighestActivePriority()
             ))
         );
+
+    public bool UsePatches
+    {
+        get => SettingsService.Get<bool>(SettingsService.USE_PATCHES_SYSTEM);
+        set
+        {
+            if (UsePatches == value)
+                return;
+
+            SettingsService.Set(SettingsService.USE_PATCHES_SYSTEM, value);
+            RefreshStorageMode();
+        }
+    }
+
+    public string StoragePageTitle => ModStorageSystemHelper.GetDisplayName(ModStorageSystemHelper.GetCurrent(SettingsService));
 
     private bool _hasMods;
 
@@ -70,8 +90,10 @@ public partial class ModsPage : UserControlBase, INotifyPropertyChanged
         DataContext = this;
         Focusable = true;
         ModManager.PropertyChanged += OnModsChanged;
+        _settingsSignalSubscription = SettingsSignalBus.Subscribe(OnSettingSignal);
         ModManager.ReloadAsync();
         SetModsViewVariant();
+        RefreshStorageMode();
 
         // Apply priority edits as soon as the user clicks anywhere outside the textbox.
         AddHandler(PointerPressedEvent, OnPagePointerPressed, RoutingStrategies.Tunnel, true);
@@ -80,6 +102,14 @@ public partial class ModsPage : UserControlBase, INotifyPropertyChanged
         PointerMoved += OnDragPointerMoved;
         PointerReleased += OnDragPointerReleased;
         PointerCaptureLost += OnDragPointerCaptureLost;
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        ModManager.PropertyChanged -= OnModsChanged;
+        _settingsSignalSubscription?.Dispose();
+        _settingsSignalSubscription = null;
+        base.OnDetachedFromVisualTree(e);
     }
 
     private void OnModsChanged(object? sender, PropertyChangedEventArgs e)
@@ -99,6 +129,18 @@ public partial class ModsPage : UserControlBase, INotifyPropertyChanged
         OnPropertyChanged(nameof(Mods));
         HasMods = ModManager.Mods.Count > 0;
         UpdateEnableAllCheckboxState();
+    }
+
+    private void OnSettingSignal(SettingChangedSignal signal)
+    {
+        if (signal.Setting == SettingsService.USE_PATCHES_SYSTEM)
+            RefreshStorageMode();
+    }
+
+    private void RefreshStorageMode()
+    {
+        OnPropertyChanged(nameof(UsePatches));
+        OnPropertyChanged(nameof(StoragePageTitle));
     }
 
     private void UpdateEnableAllCheckboxState()

--- a/WheelWizard/Views/Patterns/ModBrowserListItem.axaml
+++ b/WheelWizard/Views/Patterns/ModBrowserListItem.axaml
@@ -9,8 +9,9 @@
                                            ModAuthor="Me"/>
             
             <patterns:ModBrowserListItem Width="294" Height="89"
-                                           ModTitle="Some other mod"
-                                           ModAuthor="somebody else"/>
+                                           ModTitle="Some other mod with quite a long title"
+                                           UsesPatches="true"
+                                           ModAuthor="somebody else with also a long name and the name"/>
             
             <patterns:ModBrowserListItem Width="294" Height="89"
                                            ModTitle="Coolest mod ever made"
@@ -72,6 +73,15 @@
                                 <TextBlock Classes="TinyText" Text="By: " />
                                 <TextBlock Classes="TinyText" Text="{TemplateBinding ModAuthor}" />
                             </StackPanel>
+                            <Border x:Name="PART_PatchesBadge"
+                                    IsVisible="False"
+                                    Margin="0,6,0,0"
+                                    Padding="6,2"
+                                    Background="#1E5E3A"
+                                    CornerRadius="9999"
+                                    HorizontalAlignment="Left">
+                                <TextBlock Classes="TinyText" Text="Uses Patches!" Foreground="#D6FFE2" />
+                            </Border>
                         </StackPanel>
                         
                         <!-- Icon -->
@@ -124,6 +134,16 @@
                         
                         <Style Selector="ListBoxItem:selected Border#PART_ModItemBorder, patterns|ModBrowserListItem.TestSelected Border#PART_ModItemBorder">
                             <Style Selector="^ Border#PART_OverlayBorder, ^ Border#PART_SelectedBlur">
+                                <Setter Property="IsVisible" Value="True"/>
+                            </Style>
+                        </Style>
+
+                        <Style Selector="patterns|ModBrowserListItem[UsesPatches=true] Border#PART_ModItemBorder">
+                            <Setter Property="Background" Value="#173726"/>
+                            <Style Selector="^ Border#PART_ImageBorder">
+                                <Setter Property="Background" Value="#28503B"/>
+                            </Style>
+                            <Style Selector="^ Border#PART_PatchesBadge">
                                 <Setter Property="IsVisible" Value="True"/>
                             </Style>
                         </Style>

--- a/WheelWizard/Views/Patterns/ModBrowserListItem.axaml.cs
+++ b/WheelWizard/Views/Patterns/ModBrowserListItem.axaml.cs
@@ -67,6 +67,16 @@ public class ModBrowserListItem : TemplatedControl
         set => SetValue(ImageUrlProperty, value);
     }
 
+    public static readonly StyledProperty<bool> UsesPatchesProperty = AvaloniaProperty.Register<ModBrowserListItem, bool>(
+        nameof(UsesPatches)
+    );
+
+    public bool UsesPatches
+    {
+        get => GetValue(UsesPatchesProperty);
+        set => SetValue(UsesPatchesProperty, value);
+    }
+
     protected override async void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);

--- a/WheelWizard/Views/Popups/ModManagement/ModBrowserWindow.axaml
+++ b/WheelWizard/Views/Popups/ModManagement/ModBrowserWindow.axaml
@@ -14,7 +14,7 @@
                      mc:Ignorable="d" d:DesignHeight="600" d:DesignWidth="800">
     <Grid ColumnDefinitions="2*,3*" Width="800" Height="750">
         <!-- Mod List -->
-        <Grid Grid.Column="0" Margin="10" RowDefinitions="Auto,Auto,*">
+        <Grid Grid.Column="0" Margin="10" RowDefinitions="Auto,Auto,Auto,*">
             <TextBlock Classes="TinyText" Text="{x:Static lang:Phrases.Text_PoweredGamebanana}"
                        HorizontalAlignment="Left" Grid.Row="0" />
 
@@ -29,8 +29,15 @@
                                    Click="Search_Click" Margin="10,0,0,5" />
             </Grid>
 
+            <CheckBox Grid.Row="2"
+                      x:Name="PatchesOnlyToggle"
+                      Classes="Switch"
+                      Margin="0,0,0,8"
+                      Content="Patches only"
+                      Click="PatchesOnlyToggle_Click" />
+
             <!-- Mod List -->
-            <ListBox Grid.Row="2" x:Name="ModListView" SelectionMode="Single"
+            <ListBox Grid.Row="3" x:Name="ModListView" SelectionMode="Single"
                      SelectionChanged="ModListView_SelectionChanged" Padding="0"
                      Background="Transparent" BorderThickness="0"
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled"
@@ -43,6 +50,7 @@
                                                        ModAuthor="{Binding Mod.Author.Name}"
                                                        ViewCount="{Binding Mod.ViewCount}"
                                                        LikeCount="{Binding Mod.LikeCount}"
+                                                       UsesPatches="{Binding Mod.UsesPatches}"
                                                        ImageUrl="{Binding PreviewImageUrl}"
                                                         />
                     </DataTemplate>

--- a/WheelWizard/Views/Popups/ModManagement/ModBrowserWindow.axaml.cs
+++ b/WheelWizard/Views/Popups/ModManagement/ModBrowserWindow.axaml.cs
@@ -22,6 +22,7 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
 {
     // Collection to hold the mods
     private ObservableCollection<ModSearchResult> Mods { get; } = [];
+    private List<ModSearchResult> LoadedMods { get; } = [];
 
     [Inject]
     private IGameBananaSingletonService GameBananaService { get; set; } = null!;
@@ -72,8 +73,8 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
 
         _isLoading = true;
 
-        var result = await GameBananaService.GetModSearchResults(searchTerm, page);
-        Mods.Where(mod => mod.Mod.Name == "LOADING").ToList().ForEach(mod => Mods.Remove(mod));
+        var effectiveSearchTerm = GetEffectiveSearchTerm(searchTerm);
+        var result = await GameBananaService.GetModSearchResults(effectiveSearchTerm, page);
 
         if (result.IsFailure)
         {
@@ -91,13 +92,18 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
 
         foreach (var mod in newMods)
         {
-            Mods.Add(new(mod, mod.PreviewMedia != null ? mod.PreviewMedia.Images[0].BaseUrl + "/" + mod.PreviewMedia.Images[0].File : ""));
+            LoadedMods.Add(
+                new(mod, mod.PreviewMedia != null ? mod.PreviewMedia.Images[0].BaseUrl + "/" + mod.PreviewMedia.Images[0].File : "")
+            );
         }
 
-        if (!metadata.IsComplete)
-            Mods.Add(new(GameBananaService.GetLoadingPreview(), ""));
+        _hasMoreMods = !metadata.IsComplete;
         _currentPage = page;
         _isLoading = false;
+        ApplyModListFilters();
+
+        if (ShowPatchesOnly)
+            await EnsurePatchesOnlyResultsAsync();
     }
 
     /// <summary>
@@ -132,11 +138,7 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
     private async void Search_Click(object? sender, RoutedEventArgs e)
     {
         _currentSearchTerm = SearchTextBox.Text?.Trim() ?? "";
-        _currentPage = 1;
-        _hasMoreMods = true;
-
-        await Dispatcher.UIThread.InvokeAsync(Mods.Clear);
-        await LoadMods(_currentPage, _currentSearchTerm);
+        await ReloadSearchResults();
     }
 
     /// <summary>
@@ -149,7 +151,12 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
 
         var modId = -1;
         if (ModListView.SelectedItem is ModSearchResult selectedMod)
+        {
+            if (selectedMod.Mod.Name == "LOADING")
+                return;
+
             modId = selectedMod.Mod.Id;
+        }
         try
         {
             await ModDetailViewer.LoadModDetailsAsync(modId, cancellationToken: _loadCancellationToken.Token);
@@ -173,6 +180,65 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
             return;
 
         Search_Click(sender, e);
+    }
+
+    private bool ShowPatchesOnly => PatchesOnlyToggle.IsChecked == true;
+
+    private string GetEffectiveSearchTerm(string searchTerm)
+    {
+        if (ShowPatchesOnly && string.IsNullOrWhiteSpace(searchTerm))
+            return "Patches";
+
+        return searchTerm;
+    }
+
+    private async Task ReloadSearchResults()
+    {
+        _currentPage = 1;
+        _hasMoreMods = true;
+        LoadedMods.Clear();
+        await Dispatcher.UIThread.InvokeAsync(Mods.Clear);
+        await LoadMods(_currentPage, _currentSearchTerm);
+    }
+
+    private void ApplyModListFilters()
+    {
+        var selectedModId = (ModListView.SelectedItem as ModSearchResult)?.Mod.Id;
+
+        Mods.Clear();
+
+        IEnumerable<ModSearchResult> visibleMods = LoadedMods;
+        if (ShowPatchesOnly)
+        {
+            visibleMods = visibleMods.Where(mod => mod.Mod.UsesPatches);
+        }
+        else
+        {
+            visibleMods = visibleMods
+                .Select((mod, index) => new { Mod = mod, Index = index })
+                .OrderByDescending(entry => entry.Mod.Mod.UsesPatches)
+                .ThenBy(entry => entry.Index)
+                .Select(entry => entry.Mod);
+        }
+
+        foreach (var mod in visibleMods)
+            Mods.Add(mod);
+
+        if (_hasMoreMods)
+            Mods.Add(new(GameBananaService.GetLoadingPreview(), ""));
+
+        ModListView.SelectedItem = selectedModId == null ? null : Mods.FirstOrDefault(mod => mod.Mod.Id == selectedModId);
+    }
+
+    private async Task EnsurePatchesOnlyResultsAsync()
+    {
+        while (ShowPatchesOnly && _hasMoreMods && !LoadedMods.Any(mod => mod.Mod.UsesPatches))
+            await LoadMods(_currentPage + 1, _currentSearchTerm);
+    }
+
+    private async void PatchesOnlyToggle_Click(object? sender, RoutedEventArgs e)
+    {
+        await ReloadSearchResults();
     }
 
     #region Property Changed

--- a/WheelWizard/Views/Popups/ModManagement/ModBrowserWindow.axaml.cs
+++ b/WheelWizard/Views/Popups/ModManagement/ModBrowserWindow.axaml.cs
@@ -66,7 +66,7 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
     /// <summary>
     /// Loads mods for the specified page and search term.
     /// </summary>
-    private async Task LoadMods(int page, string searchTerm = "")
+    private async Task LoadMods(int page, string searchTerm = "", bool ensurePatchResults = true)
     {
         if (_isLoading || !_hasMoreMods)
             return;
@@ -102,7 +102,7 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
         _isLoading = false;
         ApplyModListFilters();
 
-        if (ShowPatchesOnly)
+        if (ShowPatchesOnly && ensurePatchResults)
             await EnsurePatchesOnlyResultsAsync();
     }
 
@@ -233,7 +233,7 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
     private async Task EnsurePatchesOnlyResultsAsync()
     {
         while (ShowPatchesOnly && _hasMoreMods && !LoadedMods.Any(mod => mod.Mod.UsesPatches))
-            await LoadMods(_currentPage + 1, _currentSearchTerm);
+            await LoadMods(_currentPage + 1, _currentSearchTerm, false);
     }
 
     private async void PatchesOnlyToggle_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Introduced Patches as an alternative mod storage system
  - Added "Use Patches" toggle in Mods section to switch between storage systems
  - Added "Patches only" filter in mod browser for quick access
  - Mods using patches are now visually identified with a badge
  - Page title automatically updates to reflect the active mod storage system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->