### PR TITLE
fix: avoid startup crash when saved appdata path is unavailable

### DIFF
--- a/WheelWizard.Test/Features/Settings/PathManagerTests.cs
+++ b/WheelWizard.Test/Features/Settings/PathManagerTests.cs
@@ -1,0 +1,27 @@
+using WheelWizard.Services;
+
+namespace WheelWizard.Test.Features.Settings;
+
+[Collection("SettingsFeature")]
+public class PathManagerTests
+{
+    [Fact]
+    public void TrySetWheelWizardAppdataPath_ReturnsFalse_WhenTargetPathIsUnavailable()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var unavailablePath = GetUnavailableWindowsPath();
+        var result = PathManager.TrySetWheelWizardAppdataPath(unavailablePath, out var errorMessage, out _);
+
+        Assert.False(result);
+        Assert.False(string.IsNullOrWhiteSpace(errorMessage));
+    }
+
+    private static string GetUnavailableWindowsPath()
+    {
+        var used = DriveInfo.GetDrives().Select(d => char.ToUpperInvariant(d.Name[0])).ToHashSet();
+        var drive = "ZYXWVUTSRQPONMLKJIHGFEDCBA".FirstOrDefault(letter => !used.Contains(letter), 'Z');
+        return $@"{drive}:\WheelWizardTests\{Guid.NewGuid():N}";
+    }
+}

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -95,11 +95,32 @@ public static class PathManager
                 return null;
 
             var normalized = FileHelper.NormalizePath(storedPath);
-            return FileHelper.PathsEqual(normalized, DefaultWheelWizardAppdataPath) ? null : normalized;
+            if (FileHelper.PathsEqual(normalized, DefaultWheelWizardAppdataPath))
+                return null;
+
+            // If a previously selected custom location is no longer available (for example,
+            // when an external drive letter changes), fall back to the default path.
+            if (!TryEnsureWheelWizardAppdataPathAccessible(normalized))
+                return null;
+
+            return normalized;
         }
         catch
         {
             return null;
+        }
+    }
+
+    private static bool TryEnsureWheelWizardAppdataPathAccessible(string normalizedPath)
+    {
+        try
+        {
+            FileHelper.EnsureDirectory(normalizedPath);
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 


### PR DESCRIPTION
## Purpose of this PR:

WheelWizard could crash on startup at logger initialization when a previously saved custom data folder points to an unavailable path (for example after external drive letter changes). This PR fixes the root cause by making appdata-path resolution resilient.

###  How to Test:

- Set `HKCU\Software\WheelWizard\AppDataLocation` to a path on an unavailable drive (for example `Z:\...` where `Z:` does not exist).
- Start WheelWizard.
- Confirm startup no longer crashes due to missing appdata path.

### What Has Been Changed:

- `PathManager` now ignores persisted custom appdata paths that cannot be created/accessed and falls back to default appdata path for startup.
- Added a regression test for unavailable target-path behavior via public `PathManager` API.

## Checklist before merging
- [x] You have created relevant tests

## Discussion points

Logger initialization failures did not surface anywhere but the Windows event logs (at least for me), which makes diagnosis harder for end users. A follow-up improvement could be either to add a fallback sink  or improve the way this error surfaces to the end user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for appdata path validation to ensure proper error handling when paths are unavailable.

* **Bug Fixes**
  * Enhanced appdata path validation with improved error reporting and accessibility checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeamWheelWizard/WheelWizard/pull/259)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->