### PR TITLE
Use RWFC update host for Retro Rewind updates

### DIFF
--- a/WheelWizard/Services/Endpoints.cs
+++ b/WheelWizard/Services/Endpoints.cs
@@ -34,7 +34,7 @@ public static class Endpoints
 
     // Retro Rewind
     public const string OldRRUrl = "http://update.rwfc.net:8000/";
-    public const string RRUrl = "https://rwfc.net/updates/";
+    public const string RRUrl = "https://update.rwfc.net/";
     public const string RRZipUrl = RRUrl + "RetroRewind/zip/RetroRewind.zip";
     public const string RRTestersZipUrl = RRUrl + "RetroRewind/zip/Testers.zip";
     public const string RRVersionUrl = RRUrl + "RetroRewind/RetroRewindVersion.txt";


### PR DESCRIPTION
## Summary

- Updates the Retro Rewind update base URL from `https://rwfc.net/updates/` to `https://update.rwfc.net/`
- Keeps the endpoint on HTTPS as requested

## Validation

- `dotnet test WheelWizard.sln --no-restore -p:BaseOutputPath=artifacts\codex-test-output\` passed: 161 tests