### PR TITLE
Fix Dolphin folder prompt wording

### DIFF
--- a/WheelWizard/Resources/Languages/Phrases.Designer.cs
+++ b/WheelWizard/Resources/Languages/Phrases.Designer.cs
@@ -1105,7 +1105,7 @@ namespace WheelWizard.Resources.Languages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If you dont know what all of this means, just click yes :) \nDolphin Emulator folder found. Would you like to use this folder?.
+        ///   Looks up a localized string similar to If you don't know what this means, click Yes.\nWould you like to use this Dolphin Emulator folder?.
         /// </summary>
         public static string Question_DolphinFound_Extra {
             get {

--- a/WheelWizard/Resources/Languages/Phrases.resx
+++ b/WheelWizard/Resources/Languages/Phrases.resx
@@ -178,7 +178,7 @@ To join a specific room, you'll need to either join through a friend, or hope to
         <value>Dolphin Emulator Folder Not Found</value>
     </data>
     <data name="Question_DolphinFound_Extra" xml:space="preserve">
-        <value>If you dont know what all of this means, just click yes :) \nDolphin Emulator folder found. Would you like to use this folder?</value>
+        <value>If you don't know what this means, click Yes.\nWould you like to use this Dolphin Emulator folder?</value>
     </data>
     <data name="MessageWarning_DolphinNotFound_Extra" xml:space="preserve">
         <value>Dolphin Emulator folder not automatically found. Please try and find the folder manually, click 'help' for more information.</value>


### PR DESCRIPTION
## Summary
- clean up the autodetected Dolphin folder prompt wording
- remove the duplicated sentence in the prompt body

Fixes #185.

## Validation
- dotnet test WheelWizard.Test/WheelWizard.Test.csproj