### PR TITLE
Handle malformed Mii data without crashing

### DIFF
--- a/WheelWizard.Test/Features/MiiSerializerTests.cs
+++ b/WheelWizard.Test/Features/MiiSerializerTests.cs
@@ -125,4 +125,27 @@ public class MiiSerializerTests
         Assert.True(result.IsFailure);
         Assert.Equal("Invalid Mii data length.", result.Error.Message);
     }
+
+    [Fact]
+    public void Deserialize_InvalidCalendarDate_ShouldFailInsteadOfThrowing()
+    {
+        var data = Convert.FromBase64String(dataList[0]);
+        ushort header = (ushort)((data[0] << 8) | data[1]);
+        header = (ushort)((header & ~(0x0F << 10)) | (2 << 10));
+        header = (ushort)((header & ~(0x1F << 5)) | (31 << 5));
+        data[0] = (byte)(header >> 8);
+        data[1] = (byte)header;
+
+        var result = MiiSerializer.Deserialize(data);
+
+        Assert.True(result.IsFailure);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidBase64_ShouldFailInsteadOfThrowing()
+    {
+        var result = MiiSerializer.Deserialize("not valid base64");
+
+        Assert.True(result.IsFailure);
+    }
 }

--- a/WheelWizard/Features/WiiManagement/MiiManagement/MiiSerializer.cs
+++ b/WheelWizard/Features/WiiManagement/MiiManagement/MiiSerializer.cs
@@ -143,9 +143,31 @@ public static class MiiSerializer
         return data;
     }
 
-    public static OperationResult<Mii> Deserialize(string data) => Deserialize(Convert.FromBase64String(data));
+    public static OperationResult<Mii> Deserialize(string data)
+    {
+        try
+        {
+            return Deserialize(Convert.FromBase64String(data));
+        }
+        catch (Exception ex)
+        {
+            return InvalidDataExc(ex);
+        }
+    }
 
     public static OperationResult<Mii> Deserialize(byte[]? data)
+    {
+        try
+        {
+            return DeserializeCore(data);
+        }
+        catch (Exception ex)
+        {
+            return InvalidDataExc(ex);
+        }
+    }
+
+    private static OperationResult<Mii> DeserializeCore(byte[]? data)
     {
         if (data == null || data.Length != 74)
             return Fail("Invalid Mii data length.", MessageTranslation.Error_MiiSerializer_MiiDataLength);
@@ -341,5 +363,10 @@ public static class MiiSerializer
     private static OperationResult<Mii> InvalidDataExc(string data)
     {
         return Fail(new InvalidDataException($"Invalid {data}"), MessageTranslation.Error_MiiSerializer_InvalidMiiData, null, [data]);
+    }
+
+    private static OperationResult<Mii> InvalidDataExc(Exception exception)
+    {
+        return Fail(exception, MessageTranslation.Error_MiiSerializer_InvalidMiiData, null, [exception.Message]);
     }
 }


### PR DESCRIPTION
## Summary
- convert malformed Mii deserialization exceptions into failure results
- cover invalid calendar bits and invalid base64 inputs with tests
- keep invalid database entries skippable instead of letting one bad Mii crash the app

Fixes #265.

## Validation
- dotnet test WheelWizard.Test/WheelWizard.Test.csproj