### PR TITLE
Fix Mii editor color selection guard

### DIFF
--- a/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorEyebrows.axaml.cs
+++ b/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorEyebrows.axaml.cs
@@ -86,7 +86,7 @@ public partial class EditorEyebrows : MiiEditorBaseControl
             return;
 
         var current = Editor.Mii.MiiEyebrows;
-        if (index == current.Type)
+        if (index == (int)current.Color)
             return;
 
         var result = MiiEyebrow.Create(

--- a/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorEyes.axaml.cs
+++ b/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorEyes.axaml.cs
@@ -83,7 +83,7 @@ public partial class EditorEyes : MiiEditorBaseControl
     private void SetEyeColor(int index)
     {
         var current = Editor.Mii.MiiEyes;
-        if (index == current.Type)
+        if (index == (int)current.Color)
             return;
 
         var result = MiiEye.Create(current.Type, current.Rotation, current.Vertical, (MiiEyeColor)index, current.Size, current.Spacing);


### PR DESCRIPTION
## Summary
- Fix eye and eyebrow color selection in the Mii editor when the selected color index matches the current feature type.
- Keep no-op behavior only for the currently selected color.

Fixes #258.
Fixes #262.

## Validation
- dotnet test WheelWizard.Test/WheelWizard.Test.csproj