### PR TITLE
Release 2.4.8

### DIFF
--- a/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
+++ b/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
@@ -55,6 +55,7 @@
   </provides>
 
   <releases>
+    <release version="2.4.8" date="2026-06-01"/>
     <release version="2.4.7" date="2026-05-27"/>
     <release version="2.4.6" date="2026-05-27"/>
     <release version="2.4.5" date="2026-05-17"/>

--- a/WheelWizard.Test/Features/MiiSerializerTests.cs
+++ b/WheelWizard.Test/Features/MiiSerializerTests.cs
@@ -125,4 +125,27 @@ public class MiiSerializerTests
         Assert.True(result.IsFailure);
         Assert.Equal("Invalid Mii data length.", result.Error.Message);
     }
+
+    [Fact]
+    public void Deserialize_InvalidCalendarDate_ShouldFailInsteadOfThrowing()
+    {
+        var data = Convert.FromBase64String(dataList[0]);
+        ushort header = (ushort)((data[0] << 8) | data[1]);
+        header = (ushort)((header & ~(0x0F << 10)) | (2 << 10));
+        header = (ushort)((header & ~(0x1F << 5)) | (31 << 5));
+        data[0] = (byte)(header >> 8);
+        data[1] = (byte)header;
+
+        var result = MiiSerializer.Deserialize(data);
+
+        Assert.True(result.IsFailure);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidBase64_ShouldFailInsteadOfThrowing()
+    {
+        var result = MiiSerializer.Deserialize("not valid base64");
+
+        Assert.True(result.IsFailure);
+    }
 }

--- a/WheelWizard.Test/Features/Settings/SettingsTests.cs
+++ b/WheelWizard.Test/Features/Settings/SettingsTests.cs
@@ -43,6 +43,32 @@ public class SettingsManagerTests
         Assert.Equal(0, manager.Get<int>(manager.FOCUSED_USER));
     }
 
+    [Theory]
+    [InlineData(0.49)]
+    [InlineData(2.01)]
+    public void SavedWindowScale_RejectsValuesOutsideBounds(double scale)
+    {
+        var manager = CreateManager(new MockFileSystem(), out _, out _, out _);
+
+        var result = manager.Set(manager.SAVED_WINDOW_SCALE, scale, skipSave: true);
+
+        Assert.False(result);
+        Assert.Equal(1.0, manager.Get<double>(manager.SAVED_WINDOW_SCALE));
+    }
+
+    [Theory]
+    [InlineData(0.49)]
+    [InlineData(2.01)]
+    public void WindowScalePreview_RejectsValuesOutsideBounds(double scale)
+    {
+        var manager = CreateManager(new MockFileSystem(), out _, out _, out _);
+
+        var result = manager.Set(manager.WINDOW_SCALE, scale, skipSave: true);
+
+        Assert.False(result);
+        Assert.Equal(1.0, manager.Get<double>(manager.WINDOW_SCALE));
+    }
+
     [Fact]
     public void ValidateCorePathSettings_ReturnsAllExpectedIssues_WhenDefaultsAreInvalid()
     {

--- a/WheelWizard/Features/CustomDistributions/RetroRewindBeta.cs
+++ b/WheelWizard/Features/CustomDistributions/RetroRewindBeta.cs
@@ -193,7 +193,8 @@ public class RetroRewindBeta : IDistribution
         badPassword = false;
         try
         {
-            using var archive = ArchiveFactory.OpenArchive(zipPath, new ReaderOptions { Password = password });
+            using var archiveStream = _fileSystem.File.OpenRead(zipPath);
+            using var archive = ArchiveFactory.OpenArchive(archiveStream, new ReaderOptions { Password = password });
             var entries = archive.Entries.Where(entry => !entry.IsDirectory).ToList();
             if (entries.Count == 0)
                 return Ok();

--- a/WheelWizard/Features/Settings/SettingsManager.cs
+++ b/WheelWizard/Features/Settings/SettingsManager.cs
@@ -116,7 +116,7 @@ public class SettingsManager : ISettingsManager
 
         ENABLE_ANIMATIONS = RegisterWhWz("EnableAnimations", true);
         TESTING_MODE_ENABLED = RegisterWhWz("TestingModeEnabled", false);
-        SAVED_WINDOW_SCALE = RegisterWhWz("WindowScale", 1.0, value => (double)(value ?? -1) >= 0.5 && (double)(value ?? -1) <= 2.0);
+        SAVED_WINDOW_SCALE = RegisterWhWz("WindowScale", 1.0, SettingValues.IsValidWindowScale);
         REMOVE_BLUR = RegisterWhWz("REMOVE_BLUR", true);
         RR_REGION = RegisterWhWz("RR_Region", MarioKartWiiEnums.Regions.None);
         WW_LANGUAGE = RegisterWhWz("WW_Language", "en", value => SettingValues.WhWzLanguages.ContainsKey((string)value!));
@@ -155,11 +155,13 @@ public class SettingsManager : ISettingsManager
         #endregion
 
         #region Virtual settings
-        WINDOW_SCALE = new VirtualSetting(
+        var windowScale = new VirtualSetting(
             typeof(double),
             value => _internalScale = (double)value!,
             () => _internalScale == -1.0 ? SAVED_WINDOW_SCALE.Get() : _internalScale
-        ).SetDependencies(SAVED_WINDOW_SCALE);
+        );
+        windowScale.SetValidation(SettingValues.IsValidWindowScale);
+        WINDOW_SCALE = windowScale.SetDependencies(SAVED_WINDOW_SCALE);
 
         RECOMMENDED_SETTINGS = new VirtualSetting(
             typeof(bool),

--- a/WheelWizard/Features/Settings/Types/SettingConstants.cs
+++ b/WheelWizard/Features/Settings/Types/SettingConstants.cs
@@ -14,8 +14,15 @@ public static class SettingValues
     // you check for this value and replace it with its corresponding value in the language file
     public const string NoName = "no name";
     public const string NoLicense = "no license";
+    public const double MinWindowScale = 0.5;
+    public const double MaxWindowScale = 2.0;
 
     public static readonly double[] WindowScales = [0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.8, 2];
+
+    public static bool IsValidWindowScale(object? value)
+    {
+        return value is double scale && scale >= MinWindowScale && scale <= MaxWindowScale;
+    }
 
     public static readonly Dictionary<string, string> GFXRenderers = new() //Display name, value
     {

--- a/WheelWizard/Features/WiiManagement/MiiManagement/MiiSerializer.cs
+++ b/WheelWizard/Features/WiiManagement/MiiManagement/MiiSerializer.cs
@@ -143,9 +143,31 @@ public static class MiiSerializer
         return data;
     }
 
-    public static OperationResult<Mii> Deserialize(string data) => Deserialize(Convert.FromBase64String(data));
+    public static OperationResult<Mii> Deserialize(string data)
+    {
+        try
+        {
+            return Deserialize(Convert.FromBase64String(data));
+        }
+        catch (Exception ex)
+        {
+            return InvalidDataExc(ex);
+        }
+    }
 
     public static OperationResult<Mii> Deserialize(byte[]? data)
+    {
+        try
+        {
+            return DeserializeCore(data);
+        }
+        catch (Exception ex)
+        {
+            return InvalidDataExc(ex);
+        }
+    }
+
+    private static OperationResult<Mii> DeserializeCore(byte[]? data)
     {
         if (data == null || data.Length != 74)
             return Fail("Invalid Mii data length.", MessageTranslation.Error_MiiSerializer_MiiDataLength);
@@ -341,5 +363,10 @@ public static class MiiSerializer
     private static OperationResult<Mii> InvalidDataExc(string data)
     {
         return Fail(new InvalidDataException($"Invalid {data}"), MessageTranslation.Error_MiiSerializer_InvalidMiiData, null, [data]);
+    }
+
+    private static OperationResult<Mii> InvalidDataExc(Exception exception)
+    {
+        return Fail(exception, MessageTranslation.Error_MiiSerializer_InvalidMiiData, null, [exception.Message]);
     }
 }

--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -77,6 +77,7 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
         InitializeComponent();
         AddLayer();
 
+        ClampSavedWindowScaleToCurrentScreen();
         OnSettingChanged(SettingsService.SAVED_WINDOW_SCALE);
         _settingsSignalSubscription = SettingsSignalBus.Subscribe(OnSettingSignal);
         UpdateTestingButtonVisibility();
@@ -148,7 +149,7 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
         // Note that this method will also be called whenever the setting changes
         if (setting == SettingsService.WINDOW_SCALE || setting == SettingsService.SAVED_WINDOW_SCALE)
         {
-            var scaleFactor = (double)setting.Get();
+            var scaleFactor = GetUsableWindowScale((double)setting.Get());
             Height = WindowHeight * scaleFactor;
             Width = WindowWidth * scaleFactor;
             CompleteGrid.RenderTransform = new ScaleTransform(scaleFactor, scaleFactor);
@@ -162,6 +163,17 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
         if (setting == SettingsService.TESTING_MODE_ENABLED)
             UpdateTestingButtonVisibility();
     }
+
+    private void ClampSavedWindowScaleToCurrentScreen()
+    {
+        var savedScale = SettingsService.Get<double>(SettingsService.SAVED_WINDOW_SCALE);
+        var usableScale = GetUsableWindowScale(savedScale);
+        if (!savedScale.Equals(usableScale))
+            SettingsService.Set(SettingsService.SAVED_WINDOW_SCALE, usableScale);
+    }
+
+    private double GetUsableWindowScale(double requestedScale) =>
+        ViewUtils.GetUsableWindowScale(requestedScale, new Size(WindowWidth, WindowHeight), this);
 
     private void UpdateModsButtonText()
     {

--- a/WheelWizard/Views/Pages/Settings/WhWzSettings.axaml.cs
+++ b/WheelWizard/Views/Pages/Settings/WhWzSettings.axaml.cs
@@ -647,8 +647,18 @@ public partial class WhWzSettings : UserControlBase
         _editingScale = true;
         var selectedScale = WindowScaleDropdown.SelectedItem?.ToString() ?? "1";
         var scale = double.Parse(selectedScale.Split(" ").Last().Replace("%", "")) / 100;
+        scale = ViewUtils.GetUsableWindowScale(scale, new Avalonia.Size(Layout.WindowWidth, Layout.WindowHeight), ViewUtils.GetLayout());
+        var selectedItemText = ScaleToString(scale);
+        if (!WindowScaleDropdown.Items.Contains(selectedItemText))
+            WindowScaleDropdown.Items.Add(selectedItemText);
+        WindowScaleDropdown.SelectedItem = selectedItemText;
 
-        SettingsService.WINDOW_SCALE.Set(scale);
+        if (!SettingsService.WINDOW_SCALE.Set(scale))
+        {
+            WindowScaleDropdown.SelectedItem = ScaleToString((double)SettingsService.WINDOW_SCALE.Get());
+            _editingScale = false;
+            return;
+        }
         var seconds = 10;
 
         string ExtraScaleText() =>

--- a/WheelWizard/Views/Popups/Base/PopupWindow.axaml.cs
+++ b/WheelWizard/Views/Popups/Base/PopupWindow.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using WheelWizard.Settings;
 using WheelWizard.Shared.DependencyInjection;
+using WheelWizard.Views;
 
 namespace WheelWizard.Views.Popups.Base;
 
@@ -147,7 +148,7 @@ public partial class PopupWindow : BaseWindow, INotifyPropertyChanged
 
     public void SetWindowSize(Size size)
     {
-        var scaleFactor = SettingsService.Get<double>(SettingsService.WINDOW_SCALE);
+        var scaleFactor = ViewUtils.GetUsableWindowScale(SettingsService.Get<double>(SettingsService.WINDOW_SCALE), size, this);
         Width = size.Width * scaleFactor;
         Height = size.Height * scaleFactor;
         CompleteGrid.RenderTransform = new ScaleTransform(scaleFactor, scaleFactor);

--- a/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorEyebrows.axaml.cs
+++ b/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorEyebrows.axaml.cs
@@ -86,7 +86,7 @@ public partial class EditorEyebrows : MiiEditorBaseControl
             return;
 
         var current = Editor.Mii.MiiEyebrows;
-        if (index == current.Type)
+        if (index == (int)current.Color)
             return;
 
         var result = MiiEyebrow.Create(

--- a/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorEyes.axaml.cs
+++ b/WheelWizard/Views/Popups/MiiManagement/MiiEditor/EditorEyes.axaml.cs
@@ -83,7 +83,7 @@ public partial class EditorEyes : MiiEditorBaseControl
     private void SetEyeColor(int index)
     {
         var current = Editor.Mii.MiiEyes;
-        if (index == current.Type)
+        if (index == (int)current.Color)
             return;
 
         var result = MiiEye.Create(current.Type, current.Rotation, current.Vertical, (MiiEyeColor)index, current.Size, current.Spacing);

--- a/WheelWizard/Views/ViewUtils.cs
+++ b/WheelWizard/Views/ViewUtils.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
 using WheelWizard.Services.LiveData;
+using WheelWizard.Settings.Types;
 using WheelWizard.Utilities.RepeatedTasks;
 
 namespace WheelWizard.Views;
@@ -25,6 +26,22 @@ public static class ViewUtils
     public static void ShowSnackbar(string message, SnackbarType type = SnackbarType.Success) => GetLayout().ShowSnackbar(message, type);
 
     public static Layout GetLayout() => Layout.Instance;
+
+    public static double GetUsableWindowScale(double requestedScale, Size unscaledSize, Window window)
+    {
+        var maxScale = SettingValues.MaxWindowScale;
+        var screen = window.Screens.ScreenFromWindow(window) ?? window.Screens.Primary;
+        if (screen != null)
+        {
+            var screenScale = screen.Scaling <= 0 ? 1 : screen.Scaling;
+            var availableWidth = screen.WorkingArea.Width / screenScale;
+            var availableHeight = screen.WorkingArea.Height / screenScale;
+            maxScale = Math.Min(maxScale, Math.Min(availableWidth / unscaledSize.Width, availableHeight / unscaledSize.Height));
+        }
+
+        maxScale = Math.Max(SettingValues.MinWindowScale, maxScale);
+        return Math.Clamp(requestedScale, SettingValues.MinWindowScale, maxScale);
+    }
 
     public static void RefreshWindow()
     {

--- a/WheelWizard/WheelWizard.csproj
+++ b/WheelWizard/WheelWizard.csproj
@@ -12,7 +12,7 @@
         <NoWarn>$(NoWarn);AVLN3001</NoWarn>
 
         <!-- Program details -->
-        <Version>2.4.7</Version>
+        <Version>2.4.8</Version>
         <Description>This program will manage RetroRewind and mods :)</Description>
         <Copyright>GNU v3.0</Copyright>
         <RepositoryUrl>https://github.com/patchzyy/WheelWizard</RepositoryUrl>


### PR DESCRIPTION
Release Wheel Wizard 2.4.8.\n\nValidation:\n- dotnet restore WheelWizard.sln\n- dotnet test WheelWizard.sln --configuration Release --verbosity normal\n- dotnet test WheelWizard.sln --configuration Release --verbosity minimal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed eyebrow and eye color selection in Mii editor
  * Improved error handling for invalid Mii data during import

* **New Features**
  * Added automatic window scale adjustment based on screen resolution and bounds
  * Enhanced window scale validation with configurable minimum and maximum limits

* **Tests**
  * Added validation tests for window scale and Mii deserialization robustness

* **Chores**
  * Version bumped to 2.4.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->