### PR TITLE
Feat: rework the layout

### DIFF
--- a/WheelWizard/Views/Layout.axaml
+++ b/WheelWizard/Views/Layout.axaml
@@ -196,27 +196,52 @@
                           HorizontalAlignment="Center"
                           VerticalAlignment="Center" />
                 <Border.ContextMenu>
-                    <ContextMenu x:Name="SidebarInfoContextMenu" Placement="Top">
-                        <MenuItem IsEnabled="False">
+                    <ContextMenu x:Name="SidebarInfoContextMenu"
+                                 Placement="Pointer"
+                                 PlacementAnchor="TopLeft"
+                                 PlacementGravity="TopRight"
+                                 MinWidth="120">
+                        <ContextMenu.Styles>
+                            <Style Selector="MenuItem.MenuTextHeader">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="MenuItem">
+                                            <ContentPresenter Content="{TemplateBinding Header}"
+                                                              HorizontalAlignment="Left"
+                                                              Margin="8,6,8,4" />
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </ContextMenu.Styles>
+                        <MenuItem Classes="MenuTextHeader"
+                                  IsHitTestVisible="False"
+                                  Focusable="False">
                             <MenuItem.Header>
-                                <StackPanel Margin="4,2,4,4" HorizontalAlignment="Left">
-                                    <TextBlock Classes="TinyText" x:Name="MadeBy_Part1" Text="Made by: Patchzy" HorizontalAlignment="Left" />
-                                    <TextBlock Classes="TinyText" x:Name="MadeBy_Part2" Text="And WantToBeeMe" HorizontalAlignment="Left" />
+                                <StackPanel MinWidth="104"
+                                            HorizontalAlignment="Left">
+                                    <TextBlock Classes="TinyText" x:Name="MadeBy_Part1" Text="Made by: Patchzy" HorizontalAlignment="Left" TextAlignment="Left" />
+                                    <TextBlock Classes="TinyText" x:Name="MadeBy_Part2" Text="And WantToBeeMe" HorizontalAlignment="Left" TextAlignment="Left" />
                                 </StackPanel>
                             </MenuItem.Header>
                         </MenuItem>
                         <Separator />
-                        <MenuItem Header="{loc:T action.link.discord}" Click="Discord_Click">
+                        <MenuItem Header="{loc:T category.about}" Click="About_Click" MinWidth="120">
+                            <MenuItem.Icon>
+                                <PathIcon Data="{StaticResource InfoTip}" Width="16" Height="16" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{loc:T action.link.discord}" Click="Discord_Click" MinWidth="120">
                             <MenuItem.Icon>
                                 <PathIcon Data="{StaticResource DiscordIcon}" Width="16" Height="16" />
                             </MenuItem.Icon>
                         </MenuItem>
-                        <MenuItem Header="{loc:T action.link.github}" Click="Github_Click">
+                        <MenuItem Header="{loc:T action.link.github}" Click="Github_Click" MinWidth="120">
                             <MenuItem.Icon>
                                 <PathIcon Data="{StaticResource GithubIcon}" Width="16" Height="16" />
                             </MenuItem.Icon>
                         </MenuItem>
-                        <MenuItem Header="{loc:T action.link.support}" Click="Support_Click">
+                        <MenuItem Header="{loc:T action.link.support}" Click="Support_Click" MinWidth="120">
                             <MenuItem.Icon>
                                 <PathIcon Data="{StaticResource CoffeeIcon}" Width="16" Height="16" />
                             </MenuItem.Icon>

--- a/WheelWizard/Views/Layout.axaml
+++ b/WheelWizard/Views/Layout.axaml
@@ -8,6 +8,7 @@
         xmlns:pages="clr-namespace:WheelWizard.Views.Pages"
         xmlns:components="clr-namespace:WheelWizard.Views.Components"
         xmlns:patterns="clr-namespace:WheelWizard.Views.Patterns"
+        xmlns:miiVars="using:WheelWizard.MiiImages.Domain"
         Height="876" Width="656" WindowStartupLocation="CenterScreen"
         SystemDecorations="None"
         ExtendClientAreaToDecorationsHint="True"
@@ -57,18 +58,43 @@
         </Grid>
         
         <!-- Sidebar -->
-        <Border Grid.Column="0" Grid.Row="3"
-                Height="60"
-                Margin="10,0,10,0"
-                VerticalAlignment="Top"
-                Background="Transparent"
-                BorderBrush="{StaticResource Neutral600}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource GlobalCornerRadius}">
-            <patterns:CurrentUserProfile Margin="5,0"
-                                         VerticalAlignment="Center"
-                                         HorizontalAlignment="Stretch" />
-        </Border>
+        <Grid Grid.Column="0" Grid.Row="3"
+              Height="60"
+              Margin="10,0,10,0"
+              VerticalAlignment="Top"
+              ClipToBounds="False">
+            <Border x:Name="SidebarProfileBlock"
+                    Background="Transparent"
+                    BorderBrush="{StaticResource Neutral600}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource GlobalCornerRadius}"
+                    ClipToBounds="True"
+                    PointerEntered="SidebarProfileBlock_OnPointerEntered"
+                    PointerExited="SidebarProfileBlock_OnPointerExited"
+                    PointerMoved="SidebarProfileBlock_OnPointerMoved">
+                <Grid>
+                    <Border CornerRadius="99999" IsVisible="False" Opacity="0.3" Name="SidebarProfileHoverEffect"
+                            HorizontalAlignment="Left" VerticalAlignment="Top"
+                            Background="{StaticResource Primary200}" Height="46" Width="46" Effect="blur(150)" />
+
+                    <patterns:CurrentUserProfile x:Name="SidebarCurrentUserProfile"
+                                                 Margin="5,0"
+                                                 VerticalAlignment="Center"
+                                                 HorizontalAlignment="Stretch" />
+                </Grid>
+            </Border>
+
+            <patterns:MiiImageLoader Width="80"
+                                     Height="80"
+                                     Margin="-7,0,0,1"
+                                     HorizontalAlignment="Left"
+                                     VerticalAlignment="Bottom"
+                                     IsHitTestVisible="False"
+                                     LoadingColor="Transparent"
+                                     FallBackColor="{StaticResource Neutral600}"
+                                     Mii="{Binding Mii, ElementName=SidebarCurrentUserProfile}"
+                                     ImageVariant="{x:Static miiVars:MiiImageVariants.FriendsSideProfile}" />
+        </Grid>
 
         <TextBlock Text="{loc:T category.general}" Classes="SidebarSectionText"
                    VerticalAlignment="Bottom" Grid.Row="3" /> <!-- Repurposing this translation from settings -->
@@ -116,13 +142,13 @@
                                            Text="Kitchen Sink" x:Name="KitchenSinkButton" />
         </StackPanel>
 
-        <Grid Grid.Column="0" Grid.Row="5" ColumnDefinitions="32,8,32,8,*"
+        <Grid Grid.Column="0" Grid.Row="5" ColumnDefinitions="28,8,28,8,*"
               VerticalAlignment="Bottom" Margin="10,0,13,12" x:Name="SidebarBottomBar">
             <Border Grid.Column="0"
                     ToolTip.Tip="This only shows regions YOU have played on"
                     ToolTip.Placement="TopEdgeAlignedLeft" ToolTip.ShowDelay="20"
                     x:Name="LiveStatusBorder" IsVisible="False"
-                    Width="32" Height="32"
+                    Width="28" Height="28"
                     Classes="BottomSidebarIcon">
                 <PathIcon Width="24" Height="24"
                           Margin="-2"
@@ -161,7 +187,7 @@
 
             <Border Grid.Column="2"
                     x:Name="SidebarInfoButton"
-                    Width="32" Height="32"
+                    Width="28" Height="28"
                     Classes="BottomSidebarIcon"
                     PointerPressed="SidebarInfoButton_OnPointerPressed">
                 <PathIcon Data="{StaticResource InfoTip}"

--- a/WheelWizard/Views/Layout.axaml
+++ b/WheelWizard/Views/Layout.axaml
@@ -13,7 +13,7 @@
         ExtendClientAreaToDecorationsHint="True"
         ExtendClientAreaChromeHints="NoChrome"
         CanResize='False' Background="Transparent">
-    <Grid ColumnDefinitions="192,*" RowDefinitions="27,17,18,70,*,80" x:Name="CompleteGrid"
+    <Grid ColumnDefinitions="192,*" RowDefinitions="27,17,18,96,*,80" x:Name="CompleteGrid"
           Background="{StaticResource FrameColor}">
 
         <Border Grid.ColumnSpan="2"
@@ -46,14 +46,6 @@
                                   PointerPressed="TitleLabel_OnPointerPressed" />
         </Border>
 
-        <Border Grid.Row="4" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="10">
-            <StackPanel>
-                <TextBlock Classes="TinyText" x:Name="MadeBy_Part1" Text="Made by: Patchzy" HorizontalAlignment="Right" />
-                <TextBlock Classes="TinyText" x:Name="MadeBy_Part2" Text="And WantToBeeMe" HorizontalAlignment="Right" />
-            </StackPanel>
-        </Border>
-
-
         <Border Grid.Column="1" Grid.Row="1" Grid.RowSpan="5"
                 CornerRadius="{StaticResource WindowCornerRadiusLeftRightTwix}"
                 Background="{StaticResource BackgroundColor}" />
@@ -64,57 +56,20 @@
                                          Margin="{StaticResource EdgeGap}" />
         </Grid>
         
-        <StackPanel Grid.Row="3" Orientation="Horizontal" VerticalAlignment="Bottom"
-                    Margin="0,0,0,25">
-            <components:StateBox x:Name="PlayerCountBox" Text="0" Variant="Dark"
-                                 IconData="{StaticResource UserCouple}"
-                                 TipText="{loc:T hover.players_online.0}"
-                                 Margin="10,0,0,0" />
-            <components:StateBox x:Name="RoomCountBox" Text="0" Variant="Dark"
-                                 IconData="{StaticResource RoomUsers}"
-                                 TipText="{loc:T hover.rooms_online.0}"
-                                 Margin="10,0,0,0" />
-        </StackPanel>
-
-        <Border Grid.Column="0" Grid.Row="4" VerticalAlignment="Bottom" HorizontalAlignment="Left"
-                ToolTip.Tip="This only shows regions YOU have played on"
-                ToolTip.Placement="TopEdgeAlignedLeft" ToolTip.ShowDelay="20"
-                x:Name="LiveStatusBorder" IsVisible="False"
-                Width="32" Height="32" Margin="6">
-            <PathIcon VerticalAlignment="Stretch" HorizontalAlignment="Stretch" />
-            <Border.Styles>
-                <Style Selector="Border PathIcon">
-                    <Setter Property="Foreground" Value="Transparent" />
-                </Style>
-                <Style Selector="Border.Warning PathIcon">
-                    <Setter Property="Foreground" Value="{StaticResource Warning500}" />
-                    <Setter Property="Data" Value="{StaticResource WarningTip}" />
-                </Style>
-                <Style Selector="Border.Error PathIcon">
-                    <Setter Property="Foreground" Value="{StaticResource Danger500}" />
-                    <Setter Property="Data" Value="{StaticResource ErrorTip}" />
-                </Style>
-                <Style Selector="Border.Success PathIcon">
-                    <Setter Property="Foreground" Value="{StaticResource Primary300}" />
-                    <Setter Property="Data" Value="{StaticResource SuccessTip}" />
-                </Style>
-                <Style Selector="Border.Info PathIcon">
-                    <Setter Property="Foreground" Value="{StaticResource Neutral200}" />
-                    <Setter Property="Data" Value="{StaticResource InfoTip}" />
-                </Style>
-                <Style Selector="Border.Question PathIcon">
-                    <Setter Property="Foreground" Value="{StaticResource Warning600}" />
-                    <Setter Property="Data" Value="{StaticResource QuestionTip}" />
-                </Style>
-                <Style Selector="Border.Party PathIcon">
-                    <Setter Property="Foreground" Value="{StaticResource Danger300}" />
-                    <Setter Property="Data" Value="{StaticResource StarIcon}" />
-                </Style>
-            </Border.Styles>
+        <!-- Sidebar -->
+        <Border Grid.Column="0" Grid.Row="3"
+                Height="60"
+                Margin="10,0,10,0"
+                VerticalAlignment="Top"
+                Background="Transparent"
+                BorderBrush="{StaticResource Neutral600}"
+                BorderThickness="1"
+                CornerRadius="{StaticResource GlobalCornerRadius}">
+            <patterns:CurrentUserProfile Margin="5,0"
+                                         VerticalAlignment="Center"
+                                         HorizontalAlignment="Stretch" />
         </Border>
 
-
-        <!-- Sidebar -->
         <TextBlock Text="{loc:T category.general}" Classes="SidebarSectionText"
                    VerticalAlignment="Bottom" Grid.Row="3" /> <!-- Repurposing this translation from settings -->
         <StackPanel x:Name="SidePanelButtons" Grid.Column="0" Grid.Row="4" Width="192" VerticalAlignment="Top">
@@ -135,7 +90,11 @@
             <!-- Repurposing this translation from values -->
             <patterns:SidebarRadioButton IconData="{StaticResource RoomUsers}"
                                            PageType="{x:Type pages:RoomsPage}"
-                                           Text="{loc:T page_title.rooms}" x:Name="RoomsButton" />
+                                           Text="{loc:T page_title.rooms}" x:Name="RoomsButton"
+                                           BoxText="0"
+                                           BoxIconData="{StaticResource UserCouple}"
+                                           BoxIconSize="14"
+                                           BoxTip="{loc:T hover.players_online.0}" />
             <patterns:SidebarRadioButton IconData="{StaticResource Award}"
                                            PageType="{x:Type pages:LeaderboardPage}"
                                            Text="{loc:T page_title.leaderboard}" />
@@ -157,34 +116,120 @@
                                            Text="Kitchen Sink" x:Name="KitchenSinkButton" />
         </StackPanel>
 
-        <Border Grid.Column="0" Grid.Row="5" Background="{StaticResource Neutral800}">
-            <StackPanel VerticalAlignment="Center" Spacing="5">
-                <components:IconLabelButton IconData="{StaticResource DiscordIcon}"
-                                            Text="{loc:T action.link.discord}"
-                                            Foreground="{StaticResource Neutral400}"
-                                            HoverForeground="{StaticResource Primary300}"
-                                            FontSize="13"
-                                            Click="Discord_Click"
-                                            Margin="10,0,0,0"
-                                            IconSize="20" />
-                <components:IconLabelButton IconData="{StaticResource GithubIcon}"
-                                            Text="{loc:T action.link.github}"
-                                            Foreground="{StaticResource Neutral400}"
-                                            HoverForeground="{StaticResource Primary300}"
-                                            FontSize="13"
-                                            Click="Github_Click"
-                                            Margin="10,0,0,0"
-                                            IconSize="20" />
-                <components:IconLabelButton IconData="{StaticResource CoffeeIcon}"
-                                            Text="{loc:T action.link.support}"
-                                            Foreground="{StaticResource Neutral400}"
-                                            HoverForeground="{StaticResource Primary300}"
-                                            FontSize="13"
-                                            Click="Support_Click"
-                                            Margin="10,0,0,0"
-                                            IconSize="20" />
-            </StackPanel>
-        </Border>
+        <Grid Grid.Column="0" Grid.Row="5" ColumnDefinitions="32,8,32,8,*"
+              VerticalAlignment="Bottom" Margin="10,0,13,12" x:Name="SidebarBottomBar">
+            <Border Grid.Column="0"
+                    ToolTip.Tip="This only shows regions YOU have played on"
+                    ToolTip.Placement="TopEdgeAlignedLeft" ToolTip.ShowDelay="20"
+                    x:Name="LiveStatusBorder" IsVisible="False"
+                    Width="32" Height="32"
+                    Classes="BottomSidebarIcon">
+                <PathIcon Width="24" Height="24"
+                          Margin="-2"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Center" />
+                <Border.Styles>
+                    <Style Selector="Border PathIcon">
+                        <Setter Property="Foreground" Value="Transparent" />
+                    </Style>
+                    <Style Selector="Border.Warning PathIcon">
+                        <Setter Property="Foreground" Value="{StaticResource Warning500}" />
+                        <Setter Property="Data" Value="{StaticResource WarningTip}" />
+                    </Style>
+                    <Style Selector="Border.Error PathIcon">
+                        <Setter Property="Foreground" Value="{StaticResource Danger500}" />
+                        <Setter Property="Data" Value="{StaticResource ErrorTip}" />
+                    </Style>
+                    <Style Selector="Border.Success PathIcon">
+                        <Setter Property="Foreground" Value="{StaticResource Primary300}" />
+                        <Setter Property="Data" Value="{StaticResource SuccessTip}" />
+                    </Style>
+                    <Style Selector="Border.Info PathIcon">
+                        <Setter Property="Foreground" Value="{StaticResource Neutral200}" />
+                        <Setter Property="Data" Value="{StaticResource InfoTip}" />
+                    </Style>
+                    <Style Selector="Border.Question PathIcon">
+                        <Setter Property="Foreground" Value="{StaticResource Warning600}" />
+                        <Setter Property="Data" Value="{StaticResource QuestionTip}" />
+                    </Style>
+                    <Style Selector="Border.Party PathIcon">
+                        <Setter Property="Foreground" Value="{StaticResource Danger300}" />
+                        <Setter Property="Data" Value="{StaticResource StarIcon}" />
+                    </Style>
+                </Border.Styles>
+            </Border>
+
+            <Border Grid.Column="2"
+                    x:Name="SidebarInfoButton"
+                    Width="32" Height="32"
+                    Classes="BottomSidebarIcon"
+                    PointerPressed="SidebarInfoButton_OnPointerPressed">
+                <PathIcon Data="{StaticResource InfoTip}"
+                          Width="24" Height="24"
+                          Margin="-2"
+                          HorizontalAlignment="Center"
+                          VerticalAlignment="Center" />
+                <Border.ContextMenu>
+                    <ContextMenu x:Name="SidebarInfoContextMenu" Placement="Top">
+                        <MenuItem IsEnabled="False">
+                            <MenuItem.Header>
+                                <StackPanel Margin="4,2,4,4" HorizontalAlignment="Left">
+                                    <TextBlock Classes="TinyText" x:Name="MadeBy_Part1" Text="Made by: Patchzy" HorizontalAlignment="Left" />
+                                    <TextBlock Classes="TinyText" x:Name="MadeBy_Part2" Text="And WantToBeeMe" HorizontalAlignment="Left" />
+                                </StackPanel>
+                            </MenuItem.Header>
+                        </MenuItem>
+                        <Separator />
+                        <MenuItem Header="{loc:T action.link.discord}" Click="Discord_Click">
+                            <MenuItem.Icon>
+                                <PathIcon Data="{StaticResource DiscordIcon}" Width="16" Height="16" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{loc:T action.link.github}" Click="Github_Click">
+                            <MenuItem.Icon>
+                                <PathIcon Data="{StaticResource GithubIcon}" Width="16" Height="16" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{loc:T action.link.support}" Click="Support_Click">
+                            <MenuItem.Icon>
+                                <PathIcon Data="{StaticResource CoffeeIcon}" Width="16" Height="16" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                    </ContextMenu>
+                </Border.ContextMenu>
+            </Border>
+
+            <Border Grid.Column="4"
+                    Height="26"
+                    BorderThickness="1"
+                    BorderBrush="{StaticResource Neutral600}"
+                    Background="Transparent"
+                    CornerRadius="999"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Center">
+                <TextBlock x:Name="VersionTagText"
+                           Text="v0.0.0"
+                           Classes="TinyText"
+                           FontSize="13"
+                           Foreground="{StaticResource Neutral300}"
+                           FontWeight="Medium"
+                           Margin="0,0,8,0"
+                           HorizontalAlignment="Right"
+                           VerticalAlignment="Center" />
+            </Border>
+
+            <Grid.Styles>
+                <Style Selector="Border.BottomSidebarIcon">
+                    <Setter Property="Cursor" Value="Hand" />
+                </Style>
+                <Style Selector="Border#SidebarInfoButton PathIcon">
+                    <Setter Property="Foreground" Value="{StaticResource Neutral500}" />
+                </Style>
+                <Style Selector="Border.BottomSidebarIcon:pointerover PathIcon">
+                    <Setter Property="Foreground" Value="{StaticResource Neutral300}" />
+                </Style>
+            </Grid.Styles>
+        </Grid>
 
         <!-- Snackbar -->
         <Grid Grid.Column="1" Grid.Row="4" Grid.RowSpan="2" VerticalAlignment="Bottom"

--- a/WheelWizard/Views/Layout.axaml
+++ b/WheelWizard/Views/Layout.axaml
@@ -191,6 +191,7 @@
                     Classes="BottomSidebarIcon"
                     PointerPressed="SidebarInfoButton_OnPointerPressed">
                 <PathIcon Data="{StaticResource InfoTip}"
+                          x:Name="SidebarInfoIcon"
                           Width="24" Height="24"
                           Margin="-2"
                           HorizontalAlignment="Center"
@@ -215,7 +216,7 @@
                             </Style>
                         </ContextMenu.Styles>
                         <MenuItem Classes="MenuTextHeader"
-                                  IsHitTestVisible="False"
+                                  IsEnabled="False"
                                   Focusable="False">
                             <MenuItem.Header>
                                 <StackPanel MinWidth="104"
@@ -273,10 +274,13 @@
                 <Style Selector="Border.BottomSidebarIcon">
                     <Setter Property="Cursor" Value="Hand" />
                 </Style>
-                <Style Selector="Border#SidebarInfoButton PathIcon">
+                <Style Selector="PathIcon#SidebarInfoIcon">
                     <Setter Property="Foreground" Value="{StaticResource Neutral500}" />
                 </Style>
-                <Style Selector="Border.BottomSidebarIcon:pointerover PathIcon">
+                <Style Selector="Border#SidebarInfoButton:pointerover PathIcon#SidebarInfoIcon">
+                    <Setter Property="Foreground" Value="{StaticResource Neutral300}" />
+                </Style>
+                <Style Selector="Border#LiveStatusBorder:pointerover PathIcon">
                     <Setter Property="Foreground" Value="{StaticResource Neutral300}" />
                 </Style>
             </Grid.Styles>

--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -367,6 +367,34 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
         e.Handled = true;
     }
 
+    private void SidebarProfileBlock_OnPointerEntered(object? sender, PointerEventArgs e)
+    {
+        SidebarProfileBlock.Background = GetResourceBrush("Neutral800");
+        SidebarProfileBlock.BorderBrush = GetResourceBrush("Primary400");
+        SidebarProfileHoverEffect.IsVisible = true;
+    }
+
+    private void SidebarProfileBlock_OnPointerExited(object? sender, PointerEventArgs e)
+    {
+        SidebarProfileBlock.Background = Brushes.Transparent;
+        SidebarProfileBlock.BorderBrush = GetResourceBrush("Neutral600");
+        SidebarProfileHoverEffect.IsVisible = false;
+    }
+
+    private void SidebarProfileBlock_OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        var position = e.GetPosition(sender as Control);
+        SidebarProfileHoverEffect.Margin = new(
+            position.X - (SidebarProfileHoverEffect.Width / 2),
+            position.Y - (SidebarProfileHoverEffect.Height / 2),
+            0,
+            0
+        );
+    }
+
+    private static IBrush GetResourceBrush(string resourceName) =>
+        new SolidColorBrush((Color)Application.Current!.FindResource(resourceName)!);
+
     private void CloseButton_Click(object? sender, RoutedEventArgs e) => Close();
 
     private void MinimizeButton_Click(object? sender, RoutedEventArgs e) => WindowState = WindowState.Minimized;

--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -250,6 +250,8 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
         FriendsButton.BoxTip = t("hover.friends_online.n", friends.Count(friend => friend.IsOnline));
     }
 
+    public void UpdateSidebarProfile() => SidebarCurrentUserProfile.Refresh();
+
     public void UpdatePlayerAndRoomCount(RRLiveRooms sender)
     {
         var playerCount = sender.PlayerCount;

--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -109,6 +109,7 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
     {
         Title = BrandingService.Branding.DisplayName;
         TitleLabel.Text = BrandingService.Branding.DisplayName;
+        VersionTagText.Text = $"v{BrandingService.Branding.Version}";
         UpdateModsButtonText();
         // UpdateModsActionIndicator();
 
@@ -252,11 +253,8 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
     public void UpdatePlayerAndRoomCount(RRLiveRooms sender)
     {
         var playerCount = sender.PlayerCount;
-        var roomCount = sender.RoomCount;
-        PlayerCountBox.Text = playerCount.ToString();
-        PlayerCountBox.TipText = t("hover.players_online.n", playerCount);
-        RoomCountBox.Text = roomCount.ToString();
-        RoomCountBox.TipText = t("hover.rooms_online.n", roomCount);
+        RoomsButton.BoxText = playerCount.ToString();
+        RoomsButton.BoxTip = t("hover.players_online.n", playerCount);
         UpdateFriendCount();
     }
 
@@ -272,6 +270,7 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
 
         ToolTip.SetTip(LiveStatusBorder, sender.Status!.Message);
         LiveStatusBorder.Classes.Clear();
+        LiveStatusBorder.Classes.Add("BottomSidebarIcon");
 
         // If custom icon is provided, use it instead of variant
         if (hasCustomIcon)
@@ -362,15 +361,21 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
         TestingButton.IsVisible = SettingsService.Get<bool>(SettingsService.TESTING_MODE_ENABLED);
     }
 
+    private void SidebarInfoButton_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        SidebarInfoContextMenu.Open();
+        e.Handled = true;
+    }
+
     private void CloseButton_Click(object? sender, RoutedEventArgs e) => Close();
 
     private void MinimizeButton_Click(object? sender, RoutedEventArgs e) => WindowState = WindowState.Minimized;
 
-    private void Discord_Click(object sender, EventArgs e) => ViewUtils.OpenLink(BrandingService.Branding.DiscordUrl.ToString());
+    private void Discord_Click(object? sender, RoutedEventArgs e) => ViewUtils.OpenLink(BrandingService.Branding.DiscordUrl.ToString());
 
-    private void Github_Click(object sender, EventArgs e) => ViewUtils.OpenLink(BrandingService.Branding.RepositoryUrl.ToString());
+    private void Github_Click(object? sender, RoutedEventArgs e) => ViewUtils.OpenLink(BrandingService.Branding.RepositoryUrl.ToString());
 
-    private void Support_Click(object sender, EventArgs e) => ViewUtils.OpenLink(BrandingService.Branding.SupportUrl.ToString());
+    private void Support_Click(object? sender, RoutedEventArgs e) => ViewUtils.OpenLink(BrandingService.Branding.SupportUrl.ToString());
 
     private void CloseSnackbar_OnClick(object? sender, EventArgs e)
     {

--- a/WheelWizard/Views/Layout.axaml.cs
+++ b/WheelWizard/Views/Layout.axaml.cs
@@ -19,6 +19,7 @@ using WheelWizard.Shared.MessageTranslations;
 using WheelWizard.Utilities.RepeatedTasks;
 using WheelWizard.Views.Components;
 using WheelWizard.Views.Pages;
+using WheelWizard.Views.Pages.Settings;
 using WheelWizard.Views.Patterns;
 using WheelWizard.Views.Popups.Generic;
 using WheelWizard.WheelWizardData.Domain;
@@ -129,6 +130,7 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
     {
         UpdateModsButtonText();
         UpdateMadeByText();
+        UpdateLiveAlert();
     }
 
     private void UpdateMadeByText()
@@ -259,6 +261,8 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
         RoomsButton.BoxTip = t("hover.players_online.n", playerCount);
         UpdateFriendCount();
     }
+
+    public void UpdateLiveAlert() => UpdateLiveAlert(WhWzStatusManager.Instance);
 
     private void UpdateLiveAlert(WhWzStatusManager sender)
     {
@@ -406,6 +410,8 @@ public partial class Layout : BaseWindow, IRepeatedTaskListener
     private void Github_Click(object? sender, RoutedEventArgs e) => ViewUtils.OpenLink(BrandingService.Branding.RepositoryUrl.ToString());
 
     private void Support_Click(object? sender, RoutedEventArgs e) => ViewUtils.OpenLink(BrandingService.Branding.SupportUrl.ToString());
+
+    private void About_Click(object? sender, RoutedEventArgs e) => NavigationManager.NavigateTo<SettingsPage>(new AppInfo());
 
     private void CloseSnackbar_OnClick(object? sender, EventArgs e)
     {

--- a/WheelWizard/Views/Pages/FriendsPage.axaml
+++ b/WheelWizard/Views/Pages/FriendsPage.axaml
@@ -44,10 +44,6 @@
             </Border>
         </StackPanel>
 
-        <patterns:CurrentUserProfile Grid.Row="0" x:Name="CurrentUserProfile" Margin="10,0"
-                                     HorizontalAlignment="Right" VerticalAlignment="Top" />
-
-
         <Grid Grid.Row="1" x:Name="VisibleWhenFriends" RowDefinitions="*, 12*">
             <Grid Grid.Row="0" Margin="10,0">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,6"

--- a/WheelWizard/Views/Pages/HomePage.axaml
+++ b/WheelWizard/Views/Pages/HomePage.axaml
@@ -117,9 +117,6 @@
         <Border Grid.Row="1" Background="{StaticResource BackgroundLineColor}" Height="1" HorizontalAlignment="Stretch"
                 VerticalAlignment="Bottom" />
 
-        <behaviorComponent:CurrentUserProfile Grid.Row="0" x:Name="CurrentUserProfile" Margin="10,0"
-                                              HorizontalAlignment="Right" VerticalAlignment="Top" />
-
         <StackPanel Grid.Row="1" Orientation="Horizontal" VerticalAlignment="Top" Margin="0,6"
                     HorizontalAlignment="Right"
                     x:Name="GameModeOption">

--- a/WheelWizard/Views/Pages/LeaderboardPage.axaml
+++ b/WheelWizard/Views/Pages/LeaderboardPage.axaml
@@ -77,26 +77,10 @@
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Bottom" />
 
-        <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
-            <StackPanel Orientation="Horizontal"
-                        VerticalAlignment="Bottom"
-                        Spacing="8">
-                <TextBlock Text="Leaderboard"
-                           Classes="PageTitleText" />
-                <PathIcon Data="{StaticResource Award}"
-                          Width="16"
-                          Height="16"
-                          VerticalAlignment="Center"
-                          Foreground="{StaticResource Warning500}" />
-            </StackPanel>
-            <components:StateBox Grid.Column="1"
-                                 VerticalAlignment="Bottom"
-                                 Margin="0,0,6,10"
-                                 IconData="{StaticResource UserCouple}"
-                                 Variant="Dark"
-                                 Text="{Binding TotalPlayerCountText}"
-                                 TipText="Top 50 players" />
-        </Grid>
+        <TextBlock Grid.Row="0"
+                   Text="Leaderboard"
+                   VerticalAlignment="Bottom"
+                   Classes="PageTitleText" />
 
         <Grid Grid.Row="1">
             <StackPanel IsVisible="{Binding IsLoading}"

--- a/WheelWizard/Views/Pages/LeaderboardPage.axaml.cs
+++ b/WheelWizard/Views/Pages/LeaderboardPage.axaml.cs
@@ -78,7 +78,6 @@ public partial class LeaderboardPage : UserControlBase, INotifyPropertyChanged
     private bool _hasNoData;
     private bool _hasData;
     private string _errorMessage = string.Empty;
-    private int _loadedPlayerCount;
     private LeaderboardPlayerItem? _podiumFirst;
     private LeaderboardPlayerItem? _podiumSecond;
     private LeaderboardPlayerItem? _podiumThird;
@@ -144,8 +143,6 @@ public partial class LeaderboardPage : UserControlBase, INotifyPropertyChanged
             OnPropertyChanged(nameof(ErrorMessage));
         }
     }
-
-    public string TotalPlayerCountText => _loadedPlayerCount.ToString();
 
     public string RemainingCountText => $"{RemainingPlayers.Count} players";
 
@@ -267,9 +264,6 @@ public partial class LeaderboardPage : UserControlBase, INotifyPropertyChanged
 
         if (cancellationToken.IsCancellationRequested)
             return;
-
-        _loadedPlayerCount = mappedPlayers.Count;
-        OnPropertyChanged(nameof(TotalPlayerCountText));
 
         PodiumFirst = mappedPlayers.ElementAtOrDefault(0);
         PodiumSecond = mappedPlayers.ElementAtOrDefault(1);
@@ -409,9 +403,6 @@ public partial class LeaderboardPage : UserControlBase, INotifyPropertyChanged
         PodiumSecond = null;
         PodiumThird = null;
         RemainingPlayers.Clear();
-        _loadedPlayerCount = 0;
-
-        OnPropertyChanged(nameof(TotalPlayerCountText));
         OnPropertyChanged(nameof(RemainingCountText));
     }
 

--- a/WheelWizard/Views/Pages/MiiListPage.axaml
+++ b/WheelWizard/Views/Pages/MiiListPage.axaml
@@ -22,9 +22,6 @@
         <Border Grid.Row="1" Background="{StaticResource BackgroundLineColor}" Height="1" HorizontalAlignment="Stretch"
                 VerticalAlignment="Bottom" />
 
-        <behaviorComponent:CurrentUserProfile Grid.Row="0" x:Name="CurrentUserProfile" Margin="10,0"
-                                              HorizontalAlignment="Right" VerticalAlignment="Top" />
-
         <components:EmptyPageInfo Grid.Row="1" x:Name="VisibleWhenNoDb"
                                   HorizontalAlignment="Center" IsVisible="False"
                                   Title="{loc:T empty_content.no_miis_title}"

--- a/WheelWizard/Views/Pages/MiiListPage.axaml
+++ b/WheelWizard/Views/Pages/MiiListPage.axaml
@@ -16,9 +16,67 @@
         </Grid.RowDefinitions>
         <Border Grid.Row="0" Background="{StaticResource BackgroundLineColor}" Height="1" HorizontalAlignment="Stretch"
                 VerticalAlignment="Bottom" />
-        <TextBlock Grid.Row="0" Text="{loc:T page_title.my_miis}" HorizontalAlignment="Left"
-                   VerticalAlignment="Bottom"
-                   Classes="PageTitleText" />
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Bottom"
+                        Spacing="8">
+                <TextBlock Text="{loc:T page_title.my_miis}"
+                           Classes="PageTitleText" />
+                <components:StateBox Text="0"
+                                     IconSize="0"
+                                     x:Name="ListItemCount"
+                                     VerticalAlignment="Center" />
+            </StackPanel>
+
+            <StackPanel Grid.Column="1"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Margin="0,0,6,10"
+                        Orientation="Horizontal"
+                        Spacing="6"
+                        IsVisible="{Binding IsVisible, ElementName=VisibleWhenDb}">
+                <components:Button Text="" Click="FavMii_OnClick" x:Name="FavoriteMiiButton"
+                                   Variant="Default" Padding="10"
+                                   ToolTip.ShowDelay="0" ToolTip.Placement="Top">
+                    <components:Button.Styles>
+                        <Style Selector="components|Button">
+                            <Setter Property="IconData" Value="{StaticResource StarIcon}"/>
+                            <Setter Property="ToolTip.Tip" Value="{loc:T action.favorite}"/>
+                        </Style>
+                        <Style Selector="components|Button.UnFav">
+                            <Setter Property="IconData" Value="{StaticResource EmptyStarIcon}"/>
+                            <Setter Property="ToolTip.Tip" Value="{loc:T action.unfavorite}"/>
+                        </Style>
+                    </components:Button.Styles>
+                </components:Button>
+                <components:Button Text="" Click="EditMii_OnClick" x:Name="EditMiisButton"
+                                   IconData="{StaticResource Pen}"
+                                   Variant="Default" Padding="10" IsVisible="False"
+                                   ToolTip.ShowDelay="0" ToolTip.Placement="Top"
+                                   ToolTip.Tip="{loc:T action.edit}" />
+                <components:Button Text="" Click="DuplicateMii_OnClick" x:Name="DuplicateMiisButton"
+                                   IconData="{StaticResource Duplicate}"
+                                   Variant="Default" Padding="10" IsVisible="False"
+                                   ToolTip.ShowDelay="0" ToolTip.Placement="Top"
+                                   ToolTip.Tip="{loc:T action.duplicate}" />
+                <components:Button Text="" Click="ExportMii_OnClick" x:Name="ExportMiisButton"
+                                   IconData="{StaticResource FileExport}"
+                                   Variant="Default" Padding="10" IsVisible="False"
+                                   ToolTip.ShowDelay="0" ToolTip.Placement="Top"
+                                   ToolTip.Tip="{loc:T action.export}" />
+                <components:Button Text="" Click="DeleteMii_OnClick" x:Name="DeleteMiisButton"
+                                   IconData="{StaticResource Trash}"
+                                   Variant="Danger" Padding="10" IsVisible="False"
+                                   ToolTip.ShowDelay="0" ToolTip.Placement="Top"
+                                   ToolTip.Tip="{loc:T action.delete}" />
+                <components:Button Text="" Click="ImportMii_OnClick" x:Name="ImportMiiButton"
+                                   IconData="{StaticResource FileImport}"
+                                   Variant="Default" Padding="10"
+                                   ToolTip.ShowDelay="0" ToolTip.Placement="Top"
+                                   ToolTip.Tip="{loc:T action.import}" />
+            </StackPanel>
+        </Grid>
         <Border Grid.Row="1" Background="{StaticResource BackgroundLineColor}" Height="1" HorizontalAlignment="Stretch"
                 VerticalAlignment="Bottom" />
 
@@ -27,59 +85,8 @@
                                   Title="{loc:T empty_content.no_miis_title}"
                                   BodyText="{loc:T empty_content.no_miis}" />
 
-        <Grid x:Name="VisibleWhenDb" Grid.Row="1" RowDefinitions="54,*">
-            <Grid Grid.Row="0" Margin="10,0">
-                <StackPanel HorizontalAlignment="Right" VerticalAlignment="Center" Orientation="Horizontal"
-                            Spacing="6">
-                    <components:Button Text="" Click="FavMii_OnClick" x:Name="FavoriteMiiButton"
-                                       Variant="Default" Padding="10"
-                                       ToolTip.ShowDelay="0" ToolTip.Placement="Top">
-                        <components:Button.Styles>
-                            <Style Selector="components|Button">
-                                <Setter Property="IconData" Value="{StaticResource StarIcon}"/>
-                                <Setter Property="ToolTip.Tip" Value="{loc:T action.favorite}"/>
-                            </Style>
-                            <Style Selector="components|Button.UnFav">
-                                <Setter Property="IconData" Value="{StaticResource EmptyStarIcon}"/>
-                                <Setter Property="ToolTip.Tip" Value="{loc:T action.unfavorite}"/>
-                            </Style>
-                        </components:Button.Styles>
-                    </components:Button>
-                    <components:Button Text="" Click="EditMii_OnClick" x:Name="EditMiisButton"
-                                       IconData="{StaticResource Pen}"
-                                       Variant="Default" Padding="10" IsVisible="False"
-                                       ToolTip.ShowDelay="0" ToolTip.Placement="Top"
-                                       ToolTip.Tip="{loc:T action.edit}" />
-                    <components:Button Text="" Click="DuplicateMii_OnClick" x:Name="DuplicateMiisButton"
-                                       IconData="{StaticResource Duplicate}"
-                                       Variant="Default" Padding="10" IsVisible="False"
-                                       ToolTip.ShowDelay="0" ToolTip.Placement="Top"
-                                       ToolTip.Tip="{loc:T action.duplicate}" />
-                    <components:Button Text="" Click="ExportMii_OnClick" x:Name="ExportMiisButton"
-                                       IconData="{StaticResource FileExport}"
-                                       Variant="Default" Padding="10" IsVisible="False"
-                                       ToolTip.ShowDelay="0" ToolTip.Placement="Top"
-                                       ToolTip.Tip="{loc:T action.export}" />
-                    <components:Button Text="" Click="DeleteMii_OnClick" x:Name="DeleteMiisButton"
-                                       IconData="{StaticResource Trash}"
-                                       Variant="Danger" Padding="10" IsVisible="False"
-                                       ToolTip.ShowDelay="0" ToolTip.Placement="Top"
-                                       ToolTip.Tip="{loc:T action.delete}" />
-                    <components:Button Text="" Click="ImportMii_OnClick" x:Name="ImportMiiButton"
-                                       IconData="{StaticResource FileImport}"
-                                       Variant="Default" Padding="10"
-                                       ToolTip.ShowDelay="0" ToolTip.Placement="Top"
-                                       ToolTip.Tip="{loc:T action.import}" />
-                </StackPanel>
-
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,6">
-                    <components:FormFieldLabel Text="{loc:T list_title.miis}" />
-                    <components:StateBox Text="0" IconSize="0" x:Name="ListItemCount" />
-                </StackPanel>
-                <Border Background="{StaticResource BackgroundLineColor}" Height="1" HorizontalAlignment="Stretch"
-                        VerticalAlignment="Bottom" />
-            </Grid>
-            <ListBox Grid.Row="1" x:Name="MiiList" SelectionMode="Single" BorderThickness="0"
+        <Grid x:Name="VisibleWhenDb" Grid.Row="1">
+            <ListBox x:Name="MiiList" SelectionMode="Single" BorderThickness="0"
                      Background="Transparent" Padding="0" ItemsSource="{Binding MiiRows}"
                      ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                      ScrollViewer.VerticalScrollBarVisibility="Auto">

--- a/WheelWizard/Views/Pages/SettingsPage.axaml.cs
+++ b/WheelWizard/Views/Pages/SettingsPage.axaml.cs
@@ -19,6 +19,7 @@ public partial class SettingsPage : UserControlBase
 #endif
 
         SettingsContent.Content = initialSettingsPage;
+        SetCheckedTopBarButton(initialSettingsPage);
     }
 
     private void TopBarRadio_OnClick(object? sender, RoutedEventArgs e)
@@ -37,6 +38,17 @@ public partial class SettingsPage : UserControlBase
             return;
 
         SettingsContent.Content = instance;
+    }
+
+    private void SetCheckedTopBarButton(UserControl settingsPage)
+    {
+        foreach (var child in SettingPages.Children)
+        {
+            if (child is not RadioButton radioButton)
+                continue;
+
+            radioButton.IsChecked = radioButton.Tag?.ToString() == settingsPage.GetType().Name;
+        }
     }
 
     private void DevButton_OnClick(object? sender, RoutedEventArgs e) => new DevToolWindow().Show();

--- a/WheelWizard/Views/Pages/UserProfilePage.axaml
+++ b/WheelWizard/Views/Pages/UserProfilePage.axaml
@@ -35,6 +35,67 @@
             <Setter Property="CornerRadius" Value="6" />
             <Setter Property="Padding" Value="10" />
         </Style>
+        <Style Selector="RadioButton.ProfileSelector">
+            <Setter Property="FontSize" Value="16" />
+            <Setter Property="FontWeight" Value="Normal" />
+            <Setter Property="Foreground" Value="{StaticResource Neutral200}" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Margin" Value="0" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="RadioButton">
+                        <Border x:Name="PART_ProfileSelectorBackground"
+                                Padding="10,6"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="Transparent"
+                                BorderThickness="0"
+                                CornerRadius="0"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch">
+                            <TextBlock x:Name="PART_ProfileSelectorText"
+                                       Text="{TemplateBinding Content}"
+                                       Foreground="{TemplateBinding Foreground}"
+                                       FontSize="{TemplateBinding FontSize}"
+                                       FontWeight="{TemplateBinding FontWeight}"
+                                       TextAlignment="Center"
+                                       TextTrimming="CharacterEllipsis"
+                                       HorizontalAlignment="Stretch"
+                                       VerticalAlignment="Center" />
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+
+            <Style Selector="^:pointerover /template/ TextBlock#PART_ProfileSelectorText">
+                <Setter Property="Foreground" Value="{StaticResource Primary300}" />
+            </Style>
+
+            <Style Selector="^[IsChecked=True] /template/ Border#PART_ProfileSelectorBackground">
+                <Setter Property="Background" Value="{StaticResource Neutral900}" />
+            </Style>
+            <Style Selector="^[IsChecked=True] /template/ TextBlock#PART_ProfileSelectorText">
+                <Setter Property="Foreground" Value="White" />
+            </Style>
+
+            <Style Selector="^.First /template/ Border#PART_ProfileSelectorBackground">
+                <Setter Property="CornerRadius" Value="4,0,0,4" />
+            </Style>
+            <Style Selector="^.Last /template/ Border#PART_ProfileSelectorBackground">
+                <Setter Property="CornerRadius" Value="0,4,4,0" />
+            </Style>
+
+            <Style Selector="^[IsEnabled=False] /template/ TextBlock#PART_ProfileSelectorText">
+                <Setter Property="FontStyle" Value="Italic" />
+            </Style>
+            <Style Selector="^[IsEnabled=False]:pointerover /template/ Border#PART_ProfileSelectorBackground">
+                <Setter Property="Background" Value="Transparent" />
+            </Style>
+            <Style Selector="^[IsEnabled=False]:pointerover /template/ TextBlock#PART_ProfileSelectorText">
+                <Setter Property="Foreground" Value="{StaticResource Neutral200}" />
+            </Style>
+        </Style>
     </UserControl.Styles>
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
         <Grid.RowDefinitions>
@@ -47,42 +108,18 @@
         <Border Grid.Row="1" Background="{StaticResource BackgroundLineColor}" Height="1"
                 HorizontalAlignment="Stretch" VerticalAlignment="Bottom" />
         <TextBlock Grid.Row="0" Text="{loc:T page_title.my_profiles}" HorizontalAlignment="Left"
-                   VerticalAlignment="Top"
+                   VerticalAlignment="Bottom"
                    Classes="PageTitleText" />
 
-        <ScrollViewer Grid.Row="0" HorizontalScrollBarVisibility="Auto">
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" HorizontalAlignment="Left"
-                        x:Name="RadioButtons">
-                <!-- DON'T ADD ANYTHING TO THIS STACK PANEL OR YOU WILL RUIN THE LAYOUT -->
-                <!-- WE ARE LAZY IN THE CODE, AND SO WE USE CHILD INDEXING TO GET THE RADIO BUTTONS -->
-                <RadioButton Classes="TopBar"
-                             Click="TopBarRadio_OnClick" Tag="0"
-                             x:Name="Mii0" Content="{loc:T state.no_license}"
-                             IsChecked="True" IsEnabled="False" />
-                <RadioButton Classes="TopBar"
-                             Click="TopBarRadio_OnClick" Tag="1"
-                             x:Name="Mii1" Content="{loc:T state.no_license}"
-                             IsEnabled="False" />
-                <RadioButton Classes="TopBar"
-                             Click="TopBarRadio_OnClick" Tag="2"
-                             x:Name="Mii2" Content="{loc:T state.no_license}"
-                             IsEnabled="False" />
-                <RadioButton Classes="TopBar"
-                             Click="TopBarRadio_OnClick" Tag="3"
-                             x:Name="Mii3" Content="{loc:T state.no_license}"
-                             IsEnabled="False" />
-            </StackPanel>
-        </ScrollViewer>
-
-        <StackPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Top" Orientation="Horizontal">
-            <Border VerticalAlignment="Center" HorizontalAlignment="Center" Width="18" Height="18" Margin="10"
+        <StackPanel Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Bottom" Orientation="Horizontal">
+            <Border VerticalAlignment="Center" HorizontalAlignment="Center" Width="18" Height="18" Margin="10,0,10,12"
                     ToolTip.Tip="{loc:T hover.region_user_selection}" ToolTip.Placement="Top"
                     ToolTip.ShowDelay="20">
                 <PathIcon Foreground="{StaticResource TitleIconColor}" Margin="0"
                           HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Data="{StaticResource InfoTip}" />
             </Border>
-            <ComboBox x:Name="RegionDropdown" Margin="3,12" MinWidth="160"
-                      HorizontalAlignment="Right" VerticalAlignment="Top" />
+            <ComboBox x:Name="RegionDropdown" Margin="3,0,0,10" MinWidth="160"
+                      HorizontalAlignment="Right" VerticalAlignment="Bottom" />
         </StackPanel>
 
         <Grid Grid.Row="1" RowDefinitions="Auto,*">
@@ -90,9 +127,38 @@
                     Background="{StaticResource Neutral900}" BorderThickness="1"
                     CornerRadius="{StaticResource GlobalCornerRadius}"
                     BorderBrush="{StaticResource Neutral900}" x:Name="CurrentUserProfile" ClipToBounds="true">
-                <Grid Margin="10" RowDefinitions="216,Auto" ClipToBounds="False">
+                <Grid Margin="10" RowDefinitions="Auto,216,Auto" ClipToBounds="False">
+                    <Border Grid.Row="0"
+                            Margin="0,0,5,8"
+                            BorderBrush="{StaticResource Neutral600}"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Background="{StaticResource Neutral950}"
+                            ClipToBounds="True">
+                        <UniformGrid Columns="4" x:Name="RadioButtons">
+                            <!-- DON'T ADD ANYTHING TO THIS PANEL OR YOU WILL RUIN THE LAYOUT -->
+                            <!-- WE ARE LAZY IN THE CODE, AND SO WE USE CHILD INDEXING TO GET THE RADIO BUTTONS -->
+                            <RadioButton Classes="ProfileSelector First"
+                                         Click="TopBarRadio_OnClick" Tag="0"
+                                         x:Name="Mii0" Content="{loc:T state.no_license}"
+                                         IsChecked="True" IsEnabled="False" />
+                            <RadioButton Classes="ProfileSelector"
+                                         Click="TopBarRadio_OnClick" Tag="1"
+                                         x:Name="Mii1" Content="{loc:T state.no_license}"
+                                         IsEnabled="False" />
+                            <RadioButton Classes="ProfileSelector"
+                                         Click="TopBarRadio_OnClick" Tag="2"
+                                         x:Name="Mii2" Content="{loc:T state.no_license}"
+                                         IsEnabled="False" />
+                            <RadioButton Classes="ProfileSelector Last"
+                                         Click="TopBarRadio_OnClick" Tag="3"
+                                         x:Name="Mii3" Content="{loc:T state.no_license}"
+                                         IsEnabled="False" />
+                        </UniformGrid>
+                    </Border>
+
                     <!-- BACKGROUND & COLOR TRANSITION -->
-                    <Border Grid.Row="0" CornerRadius="99999"
+                    <Border Grid.Row="1" CornerRadius="99999"
                             HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0.5"
                             IsVisible="{Binding IsOnline}" Height="200" Width="230"
                             Background="{StaticResource Primary200}" Effect="blur(250)">
@@ -112,7 +178,7 @@
                         </Border.Styles>
                     </Border>
 
-                    <Border Grid.Row="0" BorderBrush="{StaticResource Neutral600}"
+                    <Border Grid.Row="1" BorderBrush="{StaticResource Neutral600}"
                             BorderThickness="1" Margin="0,0,5,10" CornerRadius="4" x:Name="PART_HeadBorderFace"
                             Background="{StaticResource Neutral950}">
                         <Grid>
@@ -170,7 +236,7 @@
                         </Grid>
                     </Border>
 
-                    <Grid Grid.Row="1" x:Name="CarouselNavigation" VerticalAlignment="Center" HorizontalAlignment="Center"
+                    <Grid Grid.Row="2" x:Name="CarouselNavigation" VerticalAlignment="Center" HorizontalAlignment="Center"
                           Margin="0,2,0,2" ColumnDefinitions="Auto,Auto,Auto" IsVisible="{Binding HasProfileInfo}">
                         <components:Button Grid.Column="0" IconData="{StaticResource ArrowLeft}" IconSize="12"
                                            Width="26" Height="26" Padding="0" Variant="UglyLight"
@@ -247,7 +313,7 @@
                                                       Mii="{Binding CurrentMii}"
                                                       Margin="0,0,0,15"
                                                       ImageVariant="{x:Static miiVars:MiiImageVariants.FullBodyCarousel}"
-                                                      x:Name="CurrentUserCarousel" Height="280" />
+                                                      x:Name="CurrentUserCarousel" Height="250" />
                                 </Grid>
                             </StackPanel>
                         </Border>

--- a/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
+++ b/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
@@ -250,7 +250,9 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
         // since Avalonia has some weird ass cashing, It might just be that that is because this method is actually deprecated
 
         //now we refresh the sidebar friend amount
-        ViewUtils.GetLayout().UpdateFriendCount();
+        var layout = ViewUtils.GetLayout();
+        layout.UpdateFriendCount();
+        layout.UpdateSidebarProfile();
         ViewUtils.ShowSnackbar(t("snackbar_success.profile_set_primary"));
     }
 
@@ -275,7 +277,9 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
         ViewMii(0); // Just in case you have current user set as 4. and you change to a region where there are only 3 users.
         SetUserAsPrimary();
         UpdatePage();
-        ViewUtils.GetLayout().UpdateFriendCount();
+        var layout = ViewUtils.GetLayout();
+        layout.UpdateFriendCount();
+        layout.UpdateSidebarProfile();
     }
 
     private void TopBarRadio_OnClick(object? sender, RoutedEventArgs e)
@@ -325,6 +329,7 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
         CurrentMii = selectedMii;
         GameLicenseService.LoadLicense();
         UpdatePage();
+        UpdateSidebarProfileIfCurrentUser();
         ViewUtils.ShowSnackbar(t("message_success.mii_changed"));
     }
 
@@ -390,6 +395,15 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
         //reload game data, since multiple licenses can use the same mii
         GameLicenseService.LoadLicense();
         UpdatePage();
+        UpdateSidebarProfileIfCurrentUser();
+    }
+
+    private void UpdateSidebarProfileIfCurrentUser()
+    {
+        if (FocusedUser != _currentUserIndex)
+            return;
+
+        ViewUtils.GetLayout().UpdateSidebarProfile();
     }
 
     private void MoveCarouselPage(int offset)

--- a/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
+++ b/WheelWizard/Views/Pages/UserProfilePage.axaml.cs
@@ -25,6 +25,7 @@ namespace WheelWizard.Views.Pages;
 public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
 {
     private const int ProfileCarouselPageCount = 2;
+    private const int ProfileSelectorMaxCharacters = 12;
 
     private LicenseProfile? currentPlayer;
     private Mii? _currentMii;
@@ -187,15 +188,24 @@ public partial class UserProfilePage : UserControlBase, INotifyPropertyChanged
             var noLicense = miiName == SettingValues.NoLicense;
 
             radioButton.IsEnabled = !noLicense;
-            radioButton.Content = miiName switch
+            var displayName = miiName switch
             {
                 SettingValues.NoName => t("state.no_name"),
                 SettingValues.NoLicense => t("state.no_license"),
                 _ => miiName,
             };
+            radioButton.Content = TrimProfileSelectorText(displayName);
         }
 
         UpdateCarouselIndicators();
+    }
+
+    private static string TrimProfileSelectorText(string? text)
+    {
+        if (string.IsNullOrEmpty(text) || text.Length < ProfileSelectorMaxCharacters)
+            return text ?? string.Empty;
+
+        return $"{text[..(ProfileSelectorMaxCharacters - 1)]}...";
     }
 
     private void UpdatePage()

--- a/WheelWizard/Views/Patterns/CurrentUserProfile.axaml
+++ b/WheelWizard/Views/Patterns/CurrentUserProfile.axaml
@@ -5,20 +5,8 @@
              x:Class="WheelWizard.Views.Patterns.CurrentUserProfile"
              x:DataType="behaviorComponent:CurrentUserProfile">
 
-    <StackPanel Orientation="Horizontal" Background="Transparent">
-        <StackPanel Orientation="Vertical" HorizontalAlignment="Right"
-                    VerticalAlignment="Center">
-            <TextBlock HorizontalAlignment="Right" VerticalAlignment="Center"
-                       Classes="SidebarSectionText" x:Name="PlayerNameBlock"
-                       Text="{Binding UserName}"
-                       Margin="0,0,10,0" />
-            <TextBlock HorizontalAlignment="Right" VerticalAlignment="Center"
-                       Classes="TinyText" x:Name="FriendCodeBlock"
-                       Text="{Binding FriendCode}"
-                       Margin="0,0,10,0" />
-        </StackPanel>
-
-        <Border CornerRadius="999999" ClipToBounds="True" Background="{StaticResource Neutral900}"
+    <Grid Background="Transparent" ColumnDefinitions="50,*" x:Name="ProfileRoot">
+        <Border Grid.Column="0" CornerRadius="999999" ClipToBounds="True" Background="{StaticResource Neutral900}"
                 Width="50" Height="50" x:Name="Part_MiiBall">
             <behaviorComponent:MiiImageLoader HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                                               LoadingColor="{StaticResource Neutral600}"
@@ -27,8 +15,20 @@
                                               ImageVariant="{x:Static miiVars:MiiImageVariants.CurrentUserSmall}" />
         </Border>
 
-        <StackPanel.Styles>
-            <Style Selector="StackPanel:pointerover">
+        <StackPanel Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Left"
+                    VerticalAlignment="Center" x:Name="ProfileTextPanel">
+            <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center"
+                       Classes="SidebarSectionText" x:Name="PlayerNameBlock"
+                       Text="{Binding UserName}"
+                       Margin="10,0,0,0" />
+            <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center"
+                       Classes="TinyText" x:Name="FriendCodeBlock"
+                       Text="{Binding FriendCode}"
+                       Margin="10,0,0,0" />
+        </StackPanel>
+
+        <Grid.Styles>
+            <Style Selector="Grid:pointerover">
                 <Setter Property="Cursor" Value="Hand"/>
                 <Style Selector="^ Border#Part_MiiBall">
                     <Setter Property="Background" Value="{StaticResource Neutral800}"/>
@@ -41,6 +41,6 @@
                     <Setter Property="Foreground" Value="{StaticResource Neutral300}"/>
                 </Style>
             </Style>
-        </StackPanel.Styles>
-    </StackPanel>
+        </Grid.Styles>
+    </Grid>
 </UserControl>

--- a/WheelWizard/Views/Patterns/CurrentUserProfile.axaml
+++ b/WheelWizard/Views/Patterns/CurrentUserProfile.axaml
@@ -15,6 +15,7 @@
             <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center"
                        Classes="TinyText" x:Name="FriendCodeBlock"
                        Text="{Binding FriendCode}"
+                       Foreground="{StaticResource Neutral400}"
                        Margin="10,0,0,0" />
         </StackPanel>
 

--- a/WheelWizard/Views/Patterns/CurrentUserProfile.axaml
+++ b/WheelWizard/Views/Patterns/CurrentUserProfile.axaml
@@ -1,25 +1,16 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:behaviorComponent="clr-namespace:WheelWizard.Views.Patterns"
-             xmlns:miiVars="using:WheelWizard.MiiImages.Domain"
              x:Class="WheelWizard.Views.Patterns.CurrentUserProfile"
              x:DataType="behaviorComponent:CurrentUserProfile">
 
-    <Grid Background="Transparent" ColumnDefinitions="50,*" x:Name="ProfileRoot">
-        <Border Grid.Column="0" CornerRadius="999999" ClipToBounds="True" Background="{StaticResource Neutral900}"
-                Width="50" Height="50" x:Name="Part_MiiBall">
-            <behaviorComponent:MiiImageLoader HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                              LoadingColor="{StaticResource Neutral600}"
-                                              Mii="{Binding Mii}" x:Name="Part_MiiImage"
-                                              FallBackColor="{StaticResource Neutral600}"
-                                              ImageVariant="{x:Static miiVars:MiiImageVariants.CurrentUserSmall}" />
-        </Border>
-
+    <Grid Background="Transparent" ColumnDefinitions="58,*" x:Name="ProfileRoot">
         <StackPanel Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Left"
                     VerticalAlignment="Center" x:Name="ProfileTextPanel">
             <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center"
                        Classes="SidebarSectionText" x:Name="PlayerNameBlock"
                        Text="{Binding UserName}"
+                       Foreground="{StaticResource Neutral200}"
                        Margin="10,0,0,0" />
             <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center"
                        Classes="TinyText" x:Name="FriendCodeBlock"
@@ -30,14 +21,10 @@
         <Grid.Styles>
             <Style Selector="Grid:pointerover">
                 <Setter Property="Cursor" Value="Hand"/>
-                <Style Selector="^ Border#Part_MiiBall">
-                    <Setter Property="Background" Value="{StaticResource Neutral800}"/>
+                <Style Selector="^ TextBlock#PlayerNameBlock">
+                    <Setter Property="Foreground" Value="{StaticResource Neutral100}"/>
                 </Style>
-                <Style Selector="^ behaviorComponent|MiiImageLoader#Part_MiiImage">
-                    <Setter Property="LoadingColor" Value="{StaticResource Neutral500}"/>
-                    <Setter Property="FallBackColor" Value="{StaticResource Neutral500}"/>
-                </Style>
-                <Style Selector="^ TextBlock">
+                <Style Selector="^ TextBlock#FriendCodeBlock">
                     <Setter Property="Foreground" Value="{StaticResource Neutral300}"/>
                 </Style>
             </Style>

--- a/WheelWizard/Views/Patterns/CurrentUserProfile.axaml.cs
+++ b/WheelWizard/Views/Patterns/CurrentUserProfile.axaml.cs
@@ -51,6 +51,11 @@ public partial class CurrentUserProfile : UserControlBase
         InitializeComponent();
         DataContext = this;
 
+        Refresh();
+    }
+
+    public void Refresh()
+    {
         GameLicenseService.RefreshOnlineStatus();
         GameLicenseService.LoadLicense();
 

--- a/WheelWizard/Views/Patterns/SidebarRadioButton.axaml
+++ b/WheelWizard/Views/Patterns/SidebarRadioButton.axaml
@@ -34,7 +34,7 @@
   <Style Selector="patterns|SidebarRadioButton">
     <Setter Property="Background" Value="{DynamicResource Neutral900}" />
     <Setter Property="Foreground" Value="{DynamicResource Neutral400}" />
-    <Setter Property="Height" Value="50" />
+    <Setter Property="Height" Value="46" />
     <Setter Property="GroupName" Value="SidebarRadioButton"/> <!-- Because its a radio button, they have to be in the same group to work -->
     <Setter Property="HorizontalAlignment" Value="Stretch"/>
     <Setter Property="Template">
@@ -42,10 +42,16 @@
         <Border Background="{TemplateBinding Background}"
                 BorderThickness="0" >
           <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ClipToBounds="True">
+            <Border x:Name="PART_SelectionIndicator"
+                    Width="5"
+                    CornerRadius="0"
+                    Background="Transparent"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Stretch" />
             
             <Border CornerRadius="99999" IsVisible="False" Opacity="0.3" Name="PART_HoverEffect"
                     HorizontalAlignment="Left" VerticalAlignment="Top"
-                    Background="{StaticResource Primary200}" Height="50" Width="50" Effect="blur(150)">
+                    Background="{StaticResource Primary200}" Height="46" Width="46" Effect="blur(150)">
               
               <Border.Styles>
                 <Style Selector="Border">
@@ -63,12 +69,12 @@
               </Border.Styles>
             </Border>
             
-            <components:IconLabel x:Name="RadioIcon" IconSize="25" FontSize="20"
+            <components:IconLabel x:Name="RadioIcon" IconSize="25" FontSize="19"
                              IconData="{TemplateBinding IconData}"
                              Text="{TemplateBinding Text}"
                              Foreground="{TemplateBinding Foreground}"
                              HorizontalAlignment="Left" VerticalAlignment="Center"
-                             Margin="10,0,10,0" />
+                             Margin="16,0,10,0" />
 
             <components:StateBox IsVisible="{TemplateBinding BoxText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                             x:Name="StateBox" Classes="Dark"
@@ -76,7 +82,8 @@
                             VerticalAlignment="Center" HorizontalAlignment="Right"
                             Text="{TemplateBinding BoxText}"
                             TipPlacement="Top"
-                            IconSize="0"
+                            IconData="{TemplateBinding BoxIconData}"
+                            IconSize="{TemplateBinding BoxIconSize}"
                             TipText="{TemplateBinding BoxTip}"
             />
             <!-- This will be added at a future date after patches is more stable this will turn on -->
@@ -110,6 +117,9 @@
     <Setter Property="Foreground" Value="{StaticResource Primary300}" />
     <Style Selector="^ /template/ Border#PART_HoverEffect">
       <Setter Property="IsVisible" Value="False"/>
+    </Style>
+    <Style Selector="^ /template/ Border#PART_SelectionIndicator">
+      <Setter Property="Background" Value="{StaticResource Primary400}"/>
     </Style>
   </Style>
 </Styles>

--- a/WheelWizard/Views/Patterns/SidebarRadioButton.axaml.cs
+++ b/WheelWizard/Views/Patterns/SidebarRadioButton.axaml.cs
@@ -53,6 +53,26 @@ public partial class SidebarRadioButton : RadioButton
         set => SetValue(BoxTipProperty, value);
     }
 
+    public static readonly StyledProperty<Geometry> BoxIconDataProperty = AvaloniaProperty.Register<SidebarRadioButton, Geometry>(
+        nameof(BoxIconData)
+    );
+
+    public Geometry BoxIconData
+    {
+        get => GetValue(BoxIconDataProperty);
+        set => SetValue(BoxIconDataProperty, value);
+    }
+
+    public static readonly StyledProperty<double> BoxIconSizeProperty = AvaloniaProperty.Register<SidebarRadioButton, double>(
+        nameof(BoxIconSize)
+    );
+
+    public double BoxIconSize
+    {
+        get => GetValue(BoxIconSizeProperty);
+        set => SetValue(BoxIconSizeProperty, value);
+    }
+
     //todo: after patches is more stable, uncomment this
 
     // public static readonly StyledProperty<bool> WarningVisibleProperty = AvaloniaProperty.Register<SidebarRadioButton, bool>(

--- a/WheelWizard/Views/ViewUtils.cs
+++ b/WheelWizard/Views/ViewUtils.cs
@@ -80,6 +80,7 @@ public static class ViewUtils
         }
 
         newWindow.UpdatePlayerAndRoomCount(RRLiveRooms.Instance);
+        newWindow.UpdateLiveAlert();
     }
 
     public static T? FindParent<T>(object? child, int maxSearchDepth = 10)


### PR DESCRIPTION
better layout / revamp the sidebar

major changes
- moved the user current selectedp profile in thesidebar and removed it from all the other pages having it.
- removed the bottom section that said "made by"  and that had the 3 links. instead it is now an info icon that opens a context menu with that in it
- removed the bottom section and now instead it shows 2 nice icons anda pill with the version
- changed the profile selection style a tiny bit in the my profiles page. this allowed the title and options to come down to the standrad location that all other pages also have (appart from settings)

small changes
- added a bar to the sidedbar button when it is selected, looks nice
- made the sidebar buttons a tad thinner
