### PR TITLE
fix(gamebanana): Filter out mod results with content ratings

### DIFF
--- a/WheelWizard.Test/Features/GameBananaTests.cs
+++ b/WheelWizard.Test/Features/GameBananaTests.cs
@@ -212,6 +212,7 @@ namespace WheelWizard.Test.Features
                 },
                 ModelName = "Mod",
                 PreviewMedia = new(),
+                HasContentRatings = false,
             };
         }
 

--- a/WheelWizard/Features/GameBanana/Domain/GameBananaModDetails.cs
+++ b/WheelWizard/Features/GameBanana/Domain/GameBananaModDetails.cs
@@ -63,5 +63,8 @@ public class GameBananaModDetails
     public required int DownloadCount { get; set; }
 
     [JsonPropertyName("_aFiles")]
-    public required List<GameBananaModFiles> Files { get; set; }
+    public List<GameBananaModFiles>? Files { get; set; }
+
+    [JsonPropertyName("_aArchivedFiles")]
+    public List<GameBananaModFiles>? ArchivedFiles { get; set; }
 }

--- a/WheelWizard/Features/GameBanana/Domain/GameBananaModPreview.cs
+++ b/WheelWizard/Features/GameBanana/Domain/GameBananaModPreview.cs
@@ -25,6 +25,9 @@ public class GameBananaModPreview
     [JsonPropertyName("_aPreviewMedia")]
     public required GameBananaPreviewMedia PreviewMedia { get; set; }
 
+    [JsonPropertyName("_bHasContentRatings")]
+    public required bool HasContentRatings { get; set; }
+
     [JsonPropertyName("_nLikeCount")]
     public int LikeCount { get; set; }
 

--- a/WheelWizard/Features/GameBanana/GameBananaSingletonService.cs
+++ b/WheelWizard/Features/GameBanana/GameBananaSingletonService.cs
@@ -70,6 +70,7 @@ public class GameBananaSingletonService(IApiCaller<IGameBananaApi> apiService) :
                 AvatarUrl = "",
             },
             PreviewMedia = new(),
+            HasContentRatings = false,
         };
     }
 }

--- a/WheelWizard/Services/Endpoints.cs
+++ b/WheelWizard/Services/Endpoints.cs
@@ -15,7 +15,7 @@ public static class Endpoints
     /// <summary>
     /// The base address for accessing the GameBanana API
     /// </summary>
-    public const string GameBananaBaseAddress = "https://gamebanana.com/apiv11";
+    public const string GameBananaBaseAddress = "https://gamebanana.com/apiv12";
 
     /// <summary>
     /// The address for the GitHub API
@@ -48,7 +48,4 @@ public static class Endpoints
 
     // Other
     public const string MiiChannelWAD = "-";
-
-    //GameBanana
-    public const string GameBananaBaseUrl = "https://gamebanana.com/apiv11";
 }

--- a/WheelWizard/Views/Popups/ModManagement/ModBrowserWindow.axaml.cs
+++ b/WheelWizard/Views/Popups/ModManagement/ModBrowserWindow.axaml.cs
@@ -87,7 +87,7 @@ public partial class ModBrowserWindow : PopupContent, INotifyPropertyChanged
         }
 
         var metadata = result.Value.MetaData;
-        var newMods = result.Value.Records.Where(mod => mod.ModelName == "Mod").ToList();
+        var newMods = result.Value.Records.Where(mod => mod.ModelName == "Mod" && !mod.HasContentRatings).ToList();
 
         foreach (var mod in newMods)
         {

--- a/WheelWizard/Views/Popups/ModManagement/ModContent.axaml.cs
+++ b/WheelWizard/Views/Popups/ModManagement/ModContent.axaml.cs
@@ -1,4 +1,4 @@
-using Avalonia.Interactivity;
+﻿using Avalonia.Interactivity;
 using Avalonia.Media.Imaging;
 using WheelWizard.GameBanana;
 using WheelWizard.GameBanana.Domain;
@@ -216,8 +216,13 @@ public partial class ModContent : UserControlBase
         if (prepareResult.IsFailure)
             return prepareResult.Error;
 
-        var downloadUrls = OverrideDownloadUrl != null ? [OverrideDownloadUrl] : CurrentMod.Files.Select(f => f.DownloadUrl).ToList();
-        if (!downloadUrls.Any())
+        var downloadUrls =
+            OverrideDownloadUrl != null
+                ? [OverrideDownloadUrl]
+                : CurrentMod.Files?.Select(f => f.DownloadUrl).ToList()
+                    ?? CurrentMod.ArchivedFiles?.Select(f => f.DownloadUrl).ToList()
+                    ?? [];
+        if (downloadUrls.Count == 0)
             return Fail("No downloadable files were found for this mod.");
 
         var progressWindow = new ProgressWindow(t("progress.downloading_mod", CurrentMod.Name)!);


### PR DESCRIPTION
## Purpose of this PR:
Filter out inappropriate mod results from the mod browser's search results.

###  How to Test:
Look for inappropriate mods by trying out different search strings that would normally return mods with content ratings that would be gated behind sign-ins on GameBanana itself to see the details. With this change, Wheel Wizard will not direct users to such search results anymore through its mod browser.

### What Has Been Changed:
- The GameBanana API endpoint was updated from `apiv11` to `apiv12` -- no breaking changes have been noticed.
- The `_bHasContentRatings` is respected now and results with it are filtered out from the search results.
- The `_aArchivedFiles` JSON property is also supported now, as some mods seemed to break with that property instead of `_aFiles`.

### Related Issue Link:
(There have been concerns with this in the past, so this is quite high-priority for some users.)

## Checklist before merging
- [ ] You have created relevant tests
