### PR TITLE
Fetch Retro Rewind install URL dynamically

### DIFF
--- a/WheelWizard/Features/CustomDistributions/Domain/RetroRewindApi.cs
+++ b/WheelWizard/Features/CustomDistributions/Domain/RetroRewindApi.cs
@@ -4,8 +4,8 @@ namespace WheelWizard.CustomDistributions.Domain;
 
 public interface IRetroRewindApi
 {
-    [Get("/RetroRewind/zip/RetroRewind.zip")]
-    Task<HttpContent> DownloadRetroRewindZip();
+    [Get("/RetroRewind/RetroRewindInstall.txt")]
+    Task<string> GetInstallUrl();
 
     [Get("/RetroRewind/RetroRewindVersion.txt")]
     Task<string> GetVersionFile();

--- a/WheelWizard/Features/CustomDistributions/RetroRewind.cs
+++ b/WheelWizard/Features/CustomDistributions/RetroRewind.cs
@@ -94,8 +94,16 @@ public class RetroRewind : IDistribution
                 _fileSystem.Directory.Delete(tempExtractionPath, recursive: true);
             _fileSystem.Directory.CreateDirectory(tempExtractionPath);
 
+            var installUrlResult = await _api.CallApiAsync(api => api.GetInstallUrl());
+            if (installUrlResult.IsFailure || string.IsNullOrWhiteSpace(installUrlResult.Value))
+                return Fail("Failed to get Retro Rewind download URL.");
+
             //todo, service
-            var downloadedFilePath = await DownloadHelper.DownloadToLocationAsync(Endpoints.RRZipUrl, downloadedZipPath, progressWindow);
+            var downloadedFilePath = await DownloadHelper.DownloadToLocationAsync(
+                installUrlResult.Value.Trim(),
+                downloadedZipPath,
+                progressWindow
+            );
             if (string.IsNullOrWhiteSpace(downloadedFilePath) || !_fileSystem.File.Exists(downloadedFilePath))
                 return progressWindow.WasCancellationRequested ? Ok() : Fail("Failed to download Retro Rewind files.");
 

--- a/WheelWizard/Services/Endpoints.cs
+++ b/WheelWizard/Services/Endpoints.cs
@@ -35,7 +35,6 @@ public static class Endpoints
     // Retro Rewind
     public const string OldRRUrl = "http://update.rwfc.net:8000/";
     public const string RRUrl = "https://update.rwfc.net/";
-    public const string RRZipUrl = RRUrl + "RetroRewind/zip/RetroRewind.zip";
     public const string RRTestersZipUrl = RRUrl + "RetroRewind/zip/Testers.zip";
     public const string RRVersionUrl = RRUrl + "RetroRewind/RetroRewindVersion.txt";
     public const string RRVersionDeleteUrl = RRUrl + "RetroRewind/RetroRewindDelete.txt";


### PR DESCRIPTION
## Summary

- Fetch the full Retro Rewind install URL from `RetroRewindInstall.txt`.
- Remove the hardcoded install ZIP URL.

## Why

The install location can now move without requiring a WheelWizard update.

## Impact

Retro Rewind installs continue using the current ZIP and will automatically follow future URL changes published in the pointer file.

## Validation

- `dotnet test WheelWizard.sln --configuration Release` (174 passed)
