### PR TITLE
fix: do not wipe the Retro Rewind install when a (re)install fails

### DIFF
--- a/WheelWizard.Test/Features/CustomDistributions/RetroRewindTests.cs
+++ b/WheelWizard.Test/Features/CustomDistributions/RetroRewindTests.cs
@@ -56,6 +56,42 @@ public class RetroRewindTests
     }
 
     [Fact]
+    public async Task ReinstallAsync_RecoversTheBackupOfAPreviousInterruptedInstall_WhenThereIsNoInstallLeft()
+    {
+        CreateExistingInstall();
+        // An install that got interrupted right after it moved the previous install aside.
+        _fileSystem.Directory.Move(InstallPath, BackupPath);
+        _fileSystem.File.Move(DiscXmlFilePath, BackupDiscXmlFilePath);
+        ServerIsUnreachable();
+
+        var result = await _distribution.ReinstallAsync(null!);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("6.0.0", _fileSystem.File.ReadAllText(VersionFilePath));
+        Assert.True(_fileSystem.File.Exists(DiscXmlFilePath));
+        Assert.False(_fileSystem.Directory.Exists(BackupPath));
+        Assert.False(_fileSystem.File.Exists(BackupDiscXmlFilePath));
+    }
+
+    [Fact]
+    public async Task ReinstallAsync_KeepsInstallAndPatches_WhenOnlyPartOfItCouldBeBackedUp()
+    {
+        CreateExistingInstall();
+        // A folder in the place the disc xml backup has to go makes moving that file aside fail,
+        // which only happens after the install folder already moved.
+        _fileSystem.Directory.CreateDirectory(BackupDiscXmlFilePath);
+
+        var result = await _distribution.ReinstallAsync(null!);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Failed to back up", result.Error.Message);
+        Assert.Equal("6.0.0", _fileSystem.File.ReadAllText(VersionFilePath));
+        Assert.Equal("patch", _fileSystem.File.ReadAllText(PatchFilePath));
+        Assert.True(_fileSystem.File.Exists(DiscXmlFilePath));
+        Assert.False(_fileSystem.Directory.Exists(BackupPath));
+    }
+
+    [Fact]
     public async Task RemoveAsync_DeletesTheInstallAndItsDiscXmlFile()
     {
         CreateExistingInstall();
@@ -85,6 +121,7 @@ public class RetroRewindTests
     private static string VersionFilePath => Path.Combine(InstallPath, "version.txt");
     private static string PatchFilePath => Path.Combine(PathManager.PatchesFolderPath, "MyPatch.szs");
     private static string DiscXmlFilePath => Path.Combine(PathManager.RiivolutionXmlFolderPath, "RetroRewind6.xml");
+    private static string BackupDiscXmlFilePath => $"{DiscXmlFilePath}.old";
 
     private void InitializeUserFolder()
     {

--- a/WheelWizard.Test/Features/CustomDistributions/RetroRewindTests.cs
+++ b/WheelWizard.Test/Features/CustomDistributions/RetroRewindTests.cs
@@ -1,0 +1,121 @@
+using System.Linq.Expressions;
+using Microsoft.Extensions.Logging;
+using Testably.Abstractions.Testing;
+using WheelWizard.CustomDistributions;
+using WheelWizard.CustomDistributions.Domain;
+using WheelWizard.Services;
+using WheelWizard.Settings;
+using WheelWizard.Shared;
+using WheelWizard.Shared.Services;
+
+namespace WheelWizard.Test.Features.CustomDistributions;
+
+[Collection("SettingsFeature")]
+public class RetroRewindTests
+{
+    private readonly MockFileSystem _fileSystem = new();
+    private readonly IApiCaller<IRetroRewindApi> _api = Substitute.For<IApiCaller<IRetroRewindApi>>();
+    private readonly RetroRewind _distribution;
+
+    public RetroRewindTests()
+    {
+        InitializeUserFolder();
+        _distribution = new RetroRewind(_fileSystem, _api, Substitute.For<ILogger<IDistribution>>(), Substitute.For<ISettingsManager>());
+    }
+
+    [Fact]
+    public async Task ReinstallAsync_KeepsInstallAndPatches_WhenTheServerIsUnreachable()
+    {
+        CreateExistingInstall();
+        ServerIsUnreachable();
+
+        var result = await _distribution.ReinstallAsync(null!);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("6.0.0", _fileSystem.File.ReadAllText(VersionFilePath));
+        Assert.Equal("patch", _fileSystem.File.ReadAllText(PatchFilePath));
+        Assert.True(_fileSystem.File.Exists(DiscXmlFilePath));
+        Assert.False(_fileSystem.Directory.Exists(BackupPath));
+    }
+
+    [Fact]
+    public async Task ReinstallAsync_ReplacesTheBackupOfAPreviousInterruptedInstall()
+    {
+        CreateExistingInstall();
+        _fileSystem.Directory.CreateDirectory(BackupPath);
+        var leftoverFilePath = _fileSystem.Path.Combine(BackupPath, "leftover.txt");
+        _fileSystem.File.WriteAllText(leftoverFilePath, "leftover");
+        ServerIsUnreachable();
+
+        var result = await _distribution.ReinstallAsync(null!);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("patch", _fileSystem.File.ReadAllText(PatchFilePath));
+        Assert.False(_fileSystem.File.Exists(leftoverFilePath));
+        Assert.False(_fileSystem.Directory.Exists(BackupPath));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_DeletesTheInstallAndItsDiscXmlFile()
+    {
+        CreateExistingInstall();
+
+        var result = await _distribution.RemoveAsync(null!);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(_fileSystem.Directory.Exists(InstallPath));
+        Assert.False(_fileSystem.File.Exists(DiscXmlFilePath));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_ReturnsFailure_WhenTheInstallCannotBeDeleted()
+    {
+        CreateExistingInstall();
+        using var lockedFile = _fileSystem.File.Open(VersionFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var result = await _distribution.RemoveAsync(null!);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Failed to remove", result.Error.Message);
+        Assert.True(_fileSystem.File.Exists(VersionFilePath));
+    }
+
+    private static string InstallPath => Path.Combine(PathManager.RiivolutionWhWzFolderPath, "RetroRewind6");
+    private static string BackupPath => Path.Combine(PathManager.RiivolutionWhWzFolderPath, "RetroRewind6.old");
+    private static string VersionFilePath => Path.Combine(InstallPath, "version.txt");
+    private static string PatchFilePath => Path.Combine(PathManager.PatchesFolderPath, "MyPatch.szs");
+    private static string DiscXmlFilePath => Path.Combine(PathManager.RiivolutionXmlFolderPath, "RetroRewind6.xml");
+
+    private void InitializeUserFolder()
+    {
+        var settingsManager = new SettingsManager(
+            Substitute.For<IWhWzSettingManager>(),
+            Substitute.For<IDolphinSettingManager>(),
+            _fileSystem
+        );
+#pragma warning disable CS0618
+        SettingsRuntime.Initialize(settingsManager);
+#pragma warning restore CS0618
+
+        var userFolderPath = $"/wheelwizard-user-{Guid.NewGuid():N}";
+        var loadFolderPath = _fileSystem.Path.Combine(userFolderPath, "Load");
+        _fileSystem.Directory.CreateDirectory(loadFolderPath);
+        Assert.True(settingsManager.Set(settingsManager.USER_FOLDER_PATH, userFolderPath, skipSave: true));
+        Assert.True(settingsManager.Set(settingsManager.LOAD_PATH, loadFolderPath, skipSave: true));
+    }
+
+    private void CreateExistingInstall()
+    {
+        _fileSystem.Directory.CreateDirectory(PathManager.PatchesFolderPath);
+        _fileSystem.Directory.CreateDirectory(PathManager.RiivolutionXmlFolderPath);
+        _fileSystem.File.WriteAllText(VersionFilePath, "6.0.0");
+        _fileSystem.File.WriteAllText(PatchFilePath, "patch");
+        _fileSystem.File.WriteAllText(DiscXmlFilePath, "<wiidisc/>");
+    }
+
+    private void ServerIsUnreachable()
+    {
+        _api.CallApiAsync(Arg.Any<Expression<Func<IRetroRewindApi, Task<string>>>>())
+            .Returns(Task.FromResult<OperationResult<string>>(Fail("Server offline")));
+    }
+}

--- a/WheelWizard.Test/Features/CustomDistributions/RetroRewindTests.cs
+++ b/WheelWizard.Test/Features/CustomDistributions/RetroRewindTests.cs
@@ -71,7 +71,7 @@ public class RetroRewindTests
     public async Task RemoveAsync_ReturnsFailure_WhenTheInstallCannotBeDeleted()
     {
         CreateExistingInstall();
-        using var lockedFile = _fileSystem.File.Open(VersionFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+        _fileSystem.Intercept.Event(_ => throw new IOException("The install is in use."));
 
         var result = await _distribution.RemoveAsync(null!);
 

--- a/WheelWizard/Features/CustomDistributions/RetroRewind.cs
+++ b/WheelWizard/Features/CustomDistributions/RetroRewind.cs
@@ -58,18 +58,21 @@ public class RetroRewind : IDistribution
         // That way a failed install does not take the users install (including their patches) with it.
         var backupResult = BackupCurrentInstall();
         if (backupResult.IsFailure)
+        {
+            // The backup can have moved part of the install aside before it failed, that part only lives in the backup now.
+            var rollbackResult = TryCatch(RestoreMissingFromBackup);
+            if (rollbackResult.IsFailure)
+                _logger.LogError("Failed to roll back the {Title} backup: {Error}", Title, rollbackResult.Error.Message);
             return backupResult;
+        }
 
         var installResult = await PerformInstallAsync(progressWindow);
         // A cancelled install is not a failure, but it also did not finish, so we keep the old install.
         if (installResult.IsFailure || progressWindow.WasCancellationRequested)
         {
-            if (backupResult.Value)
-            {
-                var restoreResult = RestoreBackup();
-                if (restoreResult.IsFailure)
-                    _logger.LogError("Failed to restore the previous {Title} install: {Error}", Title, restoreResult.Error.Message);
-            }
+            var restoreResult = RestoreBackup();
+            if (restoreResult.IsFailure)
+                _logger.LogError("Failed to restore the previous {Title} install: {Error}", Title, restoreResult.Error.Message);
             return installResult;
         }
 
@@ -592,52 +595,65 @@ public class RetroRewind : IDistribution
     /// <summary>
     /// Moves the current install (and its wiiDisc xml file) aside so it can be restored when the install fails.
     /// </summary>
-    /// <returns>Whether there actually was something to back up.</returns>
-    private OperationResult<bool> BackupCurrentInstall() =>
+    private OperationResult BackupCurrentInstall() =>
         TryCatch(
             () =>
             {
-                // A backup can still be there when a previous install was interrupted, that one is of no use to us anymore.
+                // A backup can still be there when a previous install was interrupted. Whatever it holds that the
+                // current install is missing is the only copy of it left, so that has to go back before we replace it.
+                RestoreMissingFromBackup();
                 DeleteBackup();
 
-                var hasBackup = false;
                 if (_fileSystem.Directory.Exists(DistributionDataPath))
-                {
                     _fileSystem.Directory.Move(DistributionDataPath, BackupDataPath);
-                    hasBackup = true;
-                }
                 if (_fileSystem.File.Exists(RiivolutionDiscXmlPath))
-                {
                     _fileSystem.File.Move(RiivolutionDiscXmlPath, BackupDiscXmlPath, overwrite: true);
-                    hasBackup = true;
-                }
-
-                return hasBackup;
             },
             $"Failed to back up the current {Title} install"
         );
 
+    /// <summary>
+    /// Puts back the parts of the backup that the current install is missing,
+    /// which is what an interrupted or half finished backup leaves behind.
+    /// </summary>
+    private void RestoreMissingFromBackup()
+    {
+        if (!_fileSystem.Directory.Exists(DistributionDataPath) && _fileSystem.Directory.Exists(BackupDataPath))
+            _fileSystem.Directory.Move(BackupDataPath, DistributionDataPath);
+        if (!_fileSystem.File.Exists(RiivolutionDiscXmlPath) && _fileSystem.File.Exists(BackupDiscXmlPath))
+            MoveDiscXmlBackupBack();
+    }
+
+    /// <summary>
+    /// Restores the install exactly as it was before it was moved aside,
+    /// so whatever the failed install added is removed as well.
+    /// </summary>
     private OperationResult RestoreBackup() =>
         TryCatch(
             () =>
             {
+                // Whatever the failed install left behind is worthless, only the backup is a real install.
+                if (_fileSystem.Directory.Exists(DistributionDataPath))
+                    _fileSystem.Directory.Delete(DistributionDataPath, recursive: true);
+                if (_fileSystem.File.Exists(RiivolutionDiscXmlPath))
+                    _fileSystem.File.Delete(RiivolutionDiscXmlPath);
+
+                // Only the parts that were there before have a backup, so this restores that exact state.
                 if (_fileSystem.Directory.Exists(BackupDataPath))
-                {
-                    // Whatever the failed install left behind is worthless, the backup is the real install.
-                    if (_fileSystem.Directory.Exists(DistributionDataPath))
-                        _fileSystem.Directory.Delete(DistributionDataPath, recursive: true);
                     _fileSystem.Directory.Move(BackupDataPath, DistributionDataPath);
-                }
                 if (_fileSystem.File.Exists(BackupDiscXmlPath))
-                {
-                    var xmlFolder = _fileSystem.Path.GetDirectoryName(RiivolutionDiscXmlPath);
-                    if (!string.IsNullOrEmpty(xmlFolder))
-                        _fileSystem.Directory.CreateDirectory(xmlFolder);
-                    _fileSystem.File.Move(BackupDiscXmlPath, RiivolutionDiscXmlPath, overwrite: true);
-                }
+                    MoveDiscXmlBackupBack();
             },
             $"Failed to restore the previous {Title} install"
         );
+
+    private void MoveDiscXmlBackupBack()
+    {
+        var xmlFolder = _fileSystem.Path.GetDirectoryName(RiivolutionDiscXmlPath);
+        if (!string.IsNullOrEmpty(xmlFolder))
+            _fileSystem.Directory.CreateDirectory(xmlFolder);
+        _fileSystem.File.Move(BackupDiscXmlPath, RiivolutionDiscXmlPath, overwrite: true);
+    }
 
     private void DeleteBackup()
     {

--- a/WheelWizard/Features/CustomDistributions/RetroRewind.cs
+++ b/WheelWizard/Features/CustomDistributions/RetroRewind.cs
@@ -41,15 +41,47 @@ public class RetroRewind : IDistribution
     public string XMLFolderName => "riivolution";
     public string XMLFileName => "RetroRewind6";
 
+    //where the RR distribution lives
+    private string DistributionDataPath => _fileSystem.Path.Combine(PathManager.RiivolutionWhWzFolderPath, FolderName);
+
+    //where the RR wiiDisc xml file lives
+    private string RiivolutionDiscXmlPath =>
+        _fileSystem.Path.Combine(PathManager.RiivolutionWhWzFolderPath, XMLFolderName, $"{XMLFileName}.xml");
+
+    //where the previous install is kept while we install a new one
+    private string BackupDataPath => $"{DistributionDataPath}.old";
+    private string BackupDiscXmlPath => $"{RiivolutionDiscXmlPath}.old";
+
     public async Task<OperationResult> InstallAsync(ProgressWindow progressWindow)
     {
-        if (GetCurrentVersion() is not null)
+        // Instead of deleting the current install, we keep it around until the new install succeeded.
+        // That way a failed install does not take the users install (including their patches) with it.
+        var backupResult = BackupCurrentInstall();
+        if (backupResult.IsFailure)
+            return backupResult;
+
+        var installResult = await PerformInstallAsync(progressWindow);
+        // A cancelled install is not a failure, but it also did not finish, so we keep the old install.
+        if (installResult.IsFailure || progressWindow.WasCancellationRequested)
         {
-            var removeResult = await RemoveAsync(progressWindow);
-            if (removeResult.IsFailure)
-                return removeResult;
+            if (backupResult.Value)
+            {
+                var restoreResult = RestoreBackup();
+                if (restoreResult.IsFailure)
+                    _logger.LogError("Failed to restore the previous {Title} install: {Error}", Title, restoreResult.Error.Message);
+            }
+            return installResult;
         }
 
+        var cleanupResult = TryCatch(DeleteBackup);
+        if (cleanupResult.IsFailure)
+            _logger.LogWarning("Failed to delete the previous {Title} install: {Error}", Title, cleanupResult.Error.Message);
+
+        return installResult;
+    }
+
+    private async Task<OperationResult> PerformInstallAsync(ProgressWindow progressWindow)
+    {
         if (HasOldRksys())
         {
             var rksysQuestion = new YesNoWindow()
@@ -543,28 +575,80 @@ public class RetroRewind : IDistribution
 
     public Task<OperationResult> RemoveAsync(ProgressWindow progressWindow)
     {
-        //where the RR distribution lives
-        var distributionDataDestination = _fileSystem.Path.Combine(PathManager.RiivolutionWhWzFolderPath, FolderName);
-        //where the RR wiiDisc xml file lives
-        var riivolutionDiscXMLFile = _fileSystem.Path.Combine(PathManager.RiivolutionWhWzFolderPath, XMLFolderName, $"{XMLFileName}.xml");
+        var result = TryCatch(
+            () =>
+            {
+                if (_fileSystem.Directory.Exists(DistributionDataPath))
+                    _fileSystem.Directory.Delete(DistributionDataPath, recursive: true);
+                if (_fileSystem.File.Exists(RiivolutionDiscXmlPath))
+                    _fileSystem.File.Delete(RiivolutionDiscXmlPath);
+            },
+            $"Failed to remove the current {Title} install"
+        );
 
-        if (_fileSystem.Directory.Exists(distributionDataDestination))
-            _fileSystem.Directory.Delete(distributionDataDestination, recursive: true);
-        if (_fileSystem.File.Exists(riivolutionDiscXMLFile))
-            _fileSystem.File.Delete(riivolutionDiscXMLFile);
-
-        return Task.FromResult(Ok());
+        return Task.FromResult(result);
     }
 
-    public async Task<OperationResult> ReinstallAsync(ProgressWindow progressWindow)
+    /// <summary>
+    /// Moves the current install (and its wiiDisc xml file) aside so it can be restored when the install fails.
+    /// </summary>
+    /// <returns>Whether there actually was something to back up.</returns>
+    private OperationResult<bool> BackupCurrentInstall() =>
+        TryCatch(
+            () =>
+            {
+                // A backup can still be there when a previous install was interrupted, that one is of no use to us anymore.
+                DeleteBackup();
+
+                var hasBackup = false;
+                if (_fileSystem.Directory.Exists(DistributionDataPath))
+                {
+                    _fileSystem.Directory.Move(DistributionDataPath, BackupDataPath);
+                    hasBackup = true;
+                }
+                if (_fileSystem.File.Exists(RiivolutionDiscXmlPath))
+                {
+                    _fileSystem.File.Move(RiivolutionDiscXmlPath, BackupDiscXmlPath, overwrite: true);
+                    hasBackup = true;
+                }
+
+                return hasBackup;
+            },
+            $"Failed to back up the current {Title} install"
+        );
+
+    private OperationResult RestoreBackup() =>
+        TryCatch(
+            () =>
+            {
+                if (_fileSystem.Directory.Exists(BackupDataPath))
+                {
+                    // Whatever the failed install left behind is worthless, the backup is the real install.
+                    if (_fileSystem.Directory.Exists(DistributionDataPath))
+                        _fileSystem.Directory.Delete(DistributionDataPath, recursive: true);
+                    _fileSystem.Directory.Move(BackupDataPath, DistributionDataPath);
+                }
+                if (_fileSystem.File.Exists(BackupDiscXmlPath))
+                {
+                    var xmlFolder = _fileSystem.Path.GetDirectoryName(RiivolutionDiscXmlPath);
+                    if (!string.IsNullOrEmpty(xmlFolder))
+                        _fileSystem.Directory.CreateDirectory(xmlFolder);
+                    _fileSystem.File.Move(BackupDiscXmlPath, RiivolutionDiscXmlPath, overwrite: true);
+                }
+            },
+            $"Failed to restore the previous {Title} install"
+        );
+
+    private void DeleteBackup()
     {
-        //Remove and install
-        var removeResult = await RemoveAsync(progressWindow);
-        if (removeResult.IsFailure)
-            return removeResult;
-
-        return await InstallAsync(progressWindow);
+        if (_fileSystem.Directory.Exists(BackupDataPath))
+            _fileSystem.Directory.Delete(BackupDataPath, recursive: true);
+        if (_fileSystem.File.Exists(BackupDiscXmlPath))
+            _fileSystem.File.Delete(BackupDiscXmlPath);
     }
+
+    // Installing already replaces the current install (and restores it when the install fails), so there is nothing extra to do here.
+    public Task<OperationResult> ReinstallAsync(ProgressWindow progressWindow) => InstallAsync(progressWindow);
 
     public async Task<OperationResult<WheelWizardStatus>> GetCurrentStatusAsync()
     {

--- a/WheelWizard/Views/Pages/Settings/OtherSettings.axaml.cs
+++ b/WheelWizard/Views/Pages/Settings/OtherSettings.axaml.cs
@@ -3,6 +3,7 @@ using WheelWizard.CustomDistributions;
 using WheelWizard.Services;
 using WheelWizard.Settings;
 using WheelWizard.Shared.DependencyInjection;
+using WheelWizard.Shared.MessageTranslations;
 using WheelWizard.Views.Popups.Generic;
 
 namespace WheelWizard.Views.Pages.Settings;
@@ -67,8 +68,11 @@ public partial class OtherSettings : UserControlBase
     {
         var progressWindow = new ProgressWindow();
         progressWindow.Show();
-        await CustomDistributionSingletonService.RetroRewind.ReinstallAsync(progressWindow);
+        var reinstallResult = await CustomDistributionSingletonService.RetroRewind.ReinstallAsync(progressWindow);
         progressWindow.Close();
+
+        if (reinstallResult.IsFailure)
+            MessageTranslationHelper.ShowMessage(reinstallResult.Error);
     }
 
     private void OpenSaveFolder_OnClick(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
**Purpose of this PR:** A failed reinstall deleted the Retro Rewind folder (including `RetroRewind6/Patches`, so the users synced mod patches) and then reported success, leaving users with nothing when the server was unreachable.

**How to Test:** Go offline (or block the RR server) and hit "Reinstall Retro Rewind" in the settings. The existing install and patches should still be there afterwards, and you now get an error popup.

**What Has Been Changed:** `InstallAsync` moves the current install and its wiiDisc xml to `RetroRewind6.old` instead of deleting them, deletes that backup only after the install succeeded, and restores it when the install fails or is cancelled (leftover backups from an interrupted run are cleaned up first). `RemoveAsync` now returns a real result instead of always returning `Ok()`, and the reinstall button surfaces failures. Added tests for these cases.

**Related Issue:** N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Retro Rewind reinstall safety by preserving the current installation and configuration if the operation fails or is canceled.
  - Reinstallations now avoid unnecessary removal steps.
  - Cleanup of interrupted-install backups is handled automatically.
  - Removal failures are reported instead of being silently ignored.
  - Reinstall errors are now displayed in Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->