### PR TITLE
task: migrate to .NET 10 LTS and drop preview Microsoft.Extensions packages

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Restore dependencies
         run: dotnet restore WheelWizard.sln

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
       "type": "process",
       "command": "dotnet",
       "args": [
-        "${workspaceFolder}/WheelWizard/bin/Debug-Windows/net8.0/win-x64/WheelWizard.dll"
+        "${workspaceFolder}/WheelWizard/bin/Debug-Windows/net10.0/win-x64/WheelWizard.dll"
       ],
       "dependsOn": "build WheelWizard Debug-Windows",
       "options": {

--- a/WheelWizard.Test/WheelWizard.Test.csproj
+++ b/WheelWizard.Test/WheelWizard.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -14,7 +14,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0-preview.3.25171.5" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
         <PackageReference Include="NSubstitute" Version="5.3.0"/>
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />

--- a/WheelWizard/WheelWizard.csproj
+++ b/WheelWizard/WheelWizard.csproj
@@ -3,7 +3,7 @@
         <!-- Program Config -->
         <StartupObject>WheelWizard.Program</StartupObject>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <RootNamespace>WheelWizard</RootNamespace>
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
@@ -33,12 +33,12 @@
 
     <ItemGroup>
         <!-- Everything specifically for Avalonia -->
-        <PackageReference Include="Avalonia" Version="11.2.5"/>
-        <PackageReference Include="Avalonia.Desktop" Version="11.2.5"/>
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.5"/>
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.5"/>
-        <PackageReference Include="Avalonia.HtmlRenderer" Version="11.0.0"/>
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.5"/>
+        <PackageReference Include="Avalonia" Version="11.3.19"/>
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.19"/>
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.19"/>
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.19"/>
+        <PackageReference Include="Avalonia.HtmlRenderer" Version="11.3.0"/>
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.19"/>
 
         <!-- Code analyzers -->
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
@@ -48,9 +48,9 @@
 
         <!-- Everything from the OG Wheel wizard project -->
         <PackageReference Include="ini-parser" Version="2.5.2" NoWarn="NU1701"/>
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0-preview.3.25171.5"/>
-        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3"/>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0"/>
         <PackageReference Include="Refit.HttpClientFactory" Version="8.0.0"/>
         <PackageReference Include="Semver" Version="3.0.0"/>
         <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0"/>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.124",
+    "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
**Purpose of this PR:** .NET 8 hits end-of-support on 2026-11-10 and we self-contained-publish the runtime into every release binary, so shipped builds would stop getting security patches. .NET 9 is already EOL, making .NET 10 LTS (supported to Nov 2028) the only forward target. Separately, `Microsoft.Extensions.Caching.Memory 10.0.0-preview.3.25171.5` was pulling six more preview assemblies into shipped binaries.

**What Has Been Changed:** `TargetFramework` to `net10.0` in both projects, `global.json` to `10.0.100`, and both workflows to `dotnet-version: 10.0.x`. Avalonia 11.2.5 -> 11.3.19 (Avalonia.HtmlRenderer 11.0.0 -> 11.3.0). `Microsoft.Extensions.Caching.Memory`, `Http.Resilience` and `Logging` all to 10.0.0 GA, which collapses the previous 8.0 / 9.x / 10.0-preview split so the whole resolved `Microsoft.Extensions.*` graph is now 10.0.0.

**Discussion Points:** The build scripts and `Flatpak/` pin no SDK/runtime versions, so they needed no changes. CSharpier.MsBuild only ships net8.0/net9.0 tool builds but its runtimeconfig sets `rollForward: Major`, so it still runs under .NET 10.
