### PR TITLE
Warn and block outdated Dolphin launches

### DIFF
--- a/WheelWizard.Test/Features/DolphinVersionTests.cs
+++ b/WheelWizard.Test/Features/DolphinVersionTests.cs
@@ -27,9 +27,8 @@ public class DolphinVersionTests
     [InlineData("2603a")]
     [InlineData("2503")]
     [InlineData("2412")]
-    // The strings found inside the official 2606 Windows binary.
+    // What the official 2606 release reports itself as.
     [InlineData("Dolphin 2606")]
-    [InlineData("Dolphin/2606")]
     // The old scheme is always older, even though its build numbers are much larger.
     // Notably "5.0-21460" must not be mined for a four-digit "2146".
     [InlineData("5.0-21460")]

--- a/WheelWizard.Test/Features/DolphinVersionTests.cs
+++ b/WheelWizard.Test/Features/DolphinVersionTests.cs
@@ -5,15 +5,15 @@ namespace WheelWizard.Test.Features;
 public class DolphinVersionTests
 {
     [Theory]
-    // The two patched builds, and anything past them.
+    // The patched point release and dev-build cutoff, and anything past them.
     [InlineData("2606a")]
     [InlineData("2606b")]
-    [InlineData("2606-235")]
-    [InlineData("2606-274")]
+    [InlineData("2606-300")]
+    [InlineData("2606-301")]
     [InlineData("2607")]
     [InlineData("2701a")]
     // The shapes we get from the actual probes rather than from a bare setting.
-    [InlineData("Dolphin 2606-274")]
+    [InlineData("Dolphin 2606-300")]
     [InlineData("  2606a\n")]
     public void GetStatus_AcceptsThePatchedBuilds(string text)
     {
@@ -23,7 +23,7 @@ public class DolphinVersionTests
     [Theory]
     // The initial 2606 release predates the point release that carries the fix.
     [InlineData("2606")]
-    [InlineData("2606-234")]
+    [InlineData("2606-299")]
     [InlineData("2603a")]
     [InlineData("2503")]
     [InlineData("2412")]

--- a/WheelWizard.Test/Features/DolphinVersionTests.cs
+++ b/WheelWizard.Test/Features/DolphinVersionTests.cs
@@ -1,0 +1,68 @@
+using WheelWizard.DolphinInstaller;
+
+namespace WheelWizard.Test.Features;
+
+public class DolphinVersionTests
+{
+    [Theory]
+    // The two patched builds, and anything past them.
+    [InlineData("2606a")]
+    [InlineData("2606b")]
+    [InlineData("2606-235")]
+    [InlineData("2606-274")]
+    [InlineData("2607")]
+    [InlineData("2701a")]
+    // The shapes we get from the actual probes rather than from a bare setting.
+    [InlineData("Dolphin 2606-274")]
+    [InlineData("  2606a\n")]
+    public void GetStatus_AcceptsThePatchedBuilds(string text)
+    {
+        Assert.Equal(DolphinVersionStatus.Supported, DolphinVersion.GetStatus(text));
+    }
+
+    [Theory]
+    // The initial 2606 release predates the point release that carries the fix.
+    [InlineData("2606")]
+    [InlineData("2606-234")]
+    [InlineData("2603a")]
+    [InlineData("2503")]
+    [InlineData("2412")]
+    // The strings found inside the official 2606 Windows binary.
+    [InlineData("Dolphin 2606")]
+    [InlineData("Dolphin/2606")]
+    // The old scheme is always older, even though its build numbers are much larger.
+    // Notably "5.0-21460" must not be mined for a four-digit "2146".
+    [InlineData("5.0-21460")]
+    [InlineData("5.0")]
+    [InlineData("Dolphin 4.0.2")]
+    public void GetStatus_RejectsEverythingOlderThanTheFix(string text)
+    {
+        Assert.Equal(DolphinVersionStatus.Outdated, DolphinVersion.GetStatus(text));
+    }
+
+    [Theory]
+    // Forks and unreadable probes fail open: we warn about what we know, not about what we guessed.
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("Ishiiruka")]
+    [InlineData("some-custom-build")]
+    // Four-digit numbers that are not a plausible year-month from the YYMM era.
+    [InlineData("2411")]
+    [InlineData("2613")]
+    [InlineData("2600")]
+    public void GetStatus_FailsOpenWhenTheVersionIsUnreadable(string? text)
+    {
+        Assert.Equal(DolphinVersionStatus.Unknown, DolphinVersion.GetStatus(text));
+    }
+
+    [Theory]
+    // What the popup shows: the version as found in the probe text.
+    [InlineData("Dolphin Emulator 2606-100", "2606-100")]
+    [InlineData("Dolphin 5.0-21460", "5.0-21460")]
+    public void GetStatus_ReturnsTheVersionAsFoundInTheText(string text, string expectedFound)
+    {
+        DolphinVersion.GetStatus(text, out var foundVersion);
+
+        Assert.Equal(expectedFound, foundVersion);
+    }
+}

--- a/WheelWizard.Test/Features/LinuxDolphinInstallerTests.cs
+++ b/WheelWizard.Test/Features/LinuxDolphinInstallerTests.cs
@@ -19,7 +19,10 @@ public class LinuxDolphinInstallerTests
     [Fact]
     public void IsDolphinInstalledInFlatpak_ReturnsTrue_WhenFlatpakListHasDolphin()
     {
-        _processService.Run("flatpak", "list --app --columns=application", out var stdOut, out _).Returns(Ok(0)).AndDoes(callInfo => callInfo[2] = "Application ID\norg.DolphinEmu.dolphin-emu\n");
+        _processService
+            .Run("flatpak", "list --app --columns=application", out var stdOut, out _)
+            .Returns(Ok(0))
+            .AndDoes(callInfo => callInfo[2] = "Application ID\norg.DolphinEmu.dolphin-emu\n");
 
         var result = _installer.IsDolphinInstalledInFlatpak();
 
@@ -29,7 +32,10 @@ public class LinuxDolphinInstallerTests
     [Fact]
     public void IsDolphinInstalledInFlatpak_ReturnsFalse_WhenFlatpakListHasNoDolphin()
     {
-        _processService.Run("flatpak", "list --app --columns=application", out var stdOut, out _).Returns(Ok(0)).AndDoes(callInfo => callInfo[2] = "Application ID\n");
+        _processService
+            .Run("flatpak", "list --app --columns=application", out var stdOut, out _)
+            .Returns(Ok(0))
+            .AndDoes(callInfo => callInfo[2] = "Application ID\n");
 
         var result = _installer.IsDolphinInstalledInFlatpak();
 

--- a/WheelWizard/Features/DolphinInstaller/DolphinInstallerExtensions.cs
+++ b/WheelWizard/Features/DolphinInstaller/DolphinInstallerExtensions.cs
@@ -13,6 +13,7 @@ public static class DolphinInstallerExtensions
         services.AddSingleton<ILinuxCommandEnvironment, LinuxCommandEnvironment>();
         services.AddSingleton<ILinuxProcessService, LinuxProcessService>();
         services.AddSingleton<ILinuxDolphinInstaller, LinuxDolphinInstaller>();
+        services.AddSingleton<IDolphinVersionService, DolphinVersionService>();
         return services;
     }
 }

--- a/WheelWizard/Features/DolphinInstaller/DolphinVersion.cs
+++ b/WheelWizard/Features/DolphinInstaller/DolphinVersion.cs
@@ -26,7 +26,7 @@ public static class DolphinVersion
     /// <summary>The oldest builds that carry the fix: release 2606a, or dev build 2606-235.</summary>
     private const int MinimumYearMonth = 2606;
     private const char MinimumRevision = 'a';
-    private const int MinimumDevBuild = 235;
+    private const int MinimumDevBuild = 300;
 
     /// <summary>The minimum, formatted the way the release notes write it, for use in user-facing text.</summary>
     public const string MinimumDisplayText = "2606a";

--- a/WheelWizard/Features/DolphinInstaller/DolphinVersion.cs
+++ b/WheelWizard/Features/DolphinInstaller/DolphinVersion.cs
@@ -1,0 +1,95 @@
+using System.Text.RegularExpressions;
+
+namespace WheelWizard.DolphinInstaller;
+
+public enum DolphinVersionStatus
+{
+    /// <summary>The installed version carries the disc-image security fixes.</summary>
+    Supported,
+
+    /// <summary>The installed version is known, and known to predate the fixes.</summary>
+    Outdated,
+
+    /// <summary>We could not read or recognize the version, so we have to assume the best.</summary>
+    Unknown,
+}
+
+/// <summary>
+/// Understands Dolphin's YYMM version scheme, e.g. "2606" (release), "2606a" (point release) or
+/// "2606-235" (dev build, 235 commits after the 2606 release).
+/// </summary>
+public static class DolphinVersion
+{
+    /// <summary>Dolphin moved from the old "5.0" style to YYMM releases with 2412.</summary>
+    private const int FirstYearMonthRelease = 2412;
+
+    /// <summary>The oldest builds that carry the fix: release 2606a, or dev build 2606-235.</summary>
+    private const int MinimumYearMonth = 2606;
+    private const char MinimumRevision = 'a';
+    private const int MinimumDevBuild = 235;
+
+    /// <summary>The minimum, formatted the way the release notes write it, for use in user-facing text.</summary>
+    public const string MinimumDisplayText = "2606a";
+
+    /// <summary>Matches a YYMM version, optionally with a point-release letter or a "-N" dev build.</summary>
+    /// <remarks>
+    /// The lookarounds keep this from matching digits inside an old-style version: in "5.0-21460" the
+    /// engine would otherwise happily take "2146" out of the middle of the build number.
+    /// </remarks>
+    private static readonly Regex VersionPattern = new(
+        @"(?<![\w.])(?<yearMonth>\d{4})(?<revision>[a-z]?)(?:-(?<devBuild>\d+))?(?![\w.])",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled
+    );
+
+    /// <summary>Matches the old "5.0" / "5.0-21460" / "4.0.2" scheme, which always predates the minimum.</summary>
+    private static readonly Regex LegacyPattern = new(@"(?<![\w.])[0-5]\.\d+(?:\.\d+)*(?:-\d+)?(?![\w])", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Judges any version text Dolphin hands us, be it a bare "2606a", the "Dolphin 2606-235" that
+    /// <c>--version</c> prints, or a Windows ProductVersion string. Also returns the version as found
+    /// in the text, for showing to the user.
+    /// </summary>
+    public static DolphinVersionStatus GetStatus(string? text, out string? foundVersion)
+    {
+        foundVersion = null;
+        if (string.IsNullOrWhiteSpace(text))
+            return DolphinVersionStatus.Unknown;
+
+        var match = VersionPattern.Match(text);
+        var yearMonth = match.Success ? int.Parse(match.Groups["yearMonth"].Value) : 0;
+
+        // A four-digit number only counts as a version when it is a plausible year-month
+        // from the era where this scheme actually existed.
+        if (yearMonth >= FirstYearMonthRelease && yearMonth % 100 is >= 1 and <= 12)
+        {
+            foundVersion = match.Value;
+            return IsAtLeastMinimum(yearMonth, match) ? DolphinVersionStatus.Supported : DolphinVersionStatus.Outdated;
+        }
+
+        var legacyMatch = LegacyPattern.Match(text);
+        if (legacyMatch.Success)
+        {
+            foundVersion = legacyMatch.Value;
+            return DolphinVersionStatus.Outdated;
+        }
+
+        return DolphinVersionStatus.Unknown;
+    }
+
+    public static DolphinVersionStatus GetStatus(string? text) => GetStatus(text, out _);
+
+    private static bool IsAtLeastMinimum(int yearMonth, Match match)
+    {
+        if (yearMonth != MinimumYearMonth)
+            return yearMonth > MinimumYearMonth;
+
+        // Within 2606 itself the two build families have their own cutoff: dev builds count commits,
+        // point releases count letters, and the two are never compared to each other.
+        var devBuildGroup = match.Groups["devBuild"];
+        if (devBuildGroup.Success)
+            return int.Parse(devBuildGroup.Value) >= MinimumDevBuild;
+
+        var revision = match.Groups["revision"].Value;
+        return revision.Length > 0 && char.ToLowerInvariant(revision[0]) >= MinimumRevision;
+    }
+}

--- a/WheelWizard/Features/DolphinInstaller/DolphinVersion.cs
+++ b/WheelWizard/Features/DolphinInstaller/DolphinVersion.cs
@@ -16,14 +16,14 @@ public enum DolphinVersionStatus
 
 /// <summary>
 /// Understands Dolphin's YYMM version scheme, e.g. "2606" (release), "2606a" (point release) or
-/// "2606-235" (dev build, 235 commits after the 2606 release).
+/// "2606-300" (dev build, 300 commits after the 2606 release).
 /// </summary>
 public static class DolphinVersion
 {
     /// <summary>Dolphin moved from the old "5.0" style to YYMM releases with 2412.</summary>
     private const int FirstYearMonthRelease = 2412;
 
-    /// <summary>The oldest builds that carry the fix: release 2606a, or dev build 2606-235.</summary>
+    /// <summary>The oldest builds that carry the fix: release 2606a, or dev build 2606-300.</summary>
     private const int MinimumYearMonth = 2606;
     private const char MinimumRevision = 'a';
     private const int MinimumDevBuild = 300;
@@ -45,7 +45,7 @@ public static class DolphinVersion
     private static readonly Regex LegacyPattern = new(@"(?<![\w.])[0-5]\.\d+(?:\.\d+)*(?:-\d+)?(?![\w])", RegexOptions.Compiled);
 
     /// <summary>
-    /// Judges any version text Dolphin hands us, be it a bare "2606a" or the "Dolphin 2606-235" that
+    /// Judges any version text Dolphin hands us, be it a bare "2606a" or the "Dolphin 2606-300" that
     /// <c>--version</c> prints. Also returns the version as found in the text, for showing to the user.
     /// </summary>
     public static DolphinVersionStatus GetStatus(string? text, out string? foundVersion)

--- a/WheelWizard/Features/DolphinInstaller/DolphinVersion.cs
+++ b/WheelWizard/Features/DolphinInstaller/DolphinVersion.cs
@@ -45,9 +45,8 @@ public static class DolphinVersion
     private static readonly Regex LegacyPattern = new(@"(?<![\w.])[0-5]\.\d+(?:\.\d+)*(?:-\d+)?(?![\w])", RegexOptions.Compiled);
 
     /// <summary>
-    /// Judges any version text Dolphin hands us, be it a bare "2606a", the "Dolphin 2606-235" that
-    /// <c>--version</c> prints, or a Windows ProductVersion string. Also returns the version as found
-    /// in the text, for showing to the user.
+    /// Judges any version text Dolphin hands us, be it a bare "2606a" or the "Dolphin 2606-235" that
+    /// <c>--version</c> prints. Also returns the version as found in the text, for showing to the user.
     /// </summary>
     public static DolphinVersionStatus GetStatus(string? text, out string? foundVersion)
     {

--- a/WheelWizard/Features/DolphinInstaller/DolphinVersionService.cs
+++ b/WheelWizard/Features/DolphinInstaller/DolphinVersionService.cs
@@ -1,6 +1,4 @@
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Text.RegularExpressions;
 using WheelWizard.Services;
 
 namespace WheelWizard.DolphinInstaller;
@@ -16,16 +14,6 @@ public interface IDolphinVersionService
 
 public sealed class DolphinVersionService(ILinuxProcessService processService) : IDolphinVersionService
 {
-    private static readonly Regex FlatpakVersionLine = new(@"^\s*Version:\s*(?<version>.+)$", RegexOptions.Multiline);
-
-    /// <summary>
-    /// The HTTP user agent Dolphin bakes into its binary, e.g. "Dolphin/2606". Deliberately not the
-    /// looser "Dolphin 2606" window-title form: the binary also embeds changelog text mentioning
-    /// other versions ("Dolphin 5.0-12188"), and mistaking one of those for the installed version
-    /// would keep warning people who already updated.
-    /// </summary>
-    private static readonly Regex WindowsBinaryVersionPattern = new(@"Dolphin/[0-9][\w.\-]*", RegexOptions.Compiled);
-
     public (DolphinVersionStatus Status, string? Version) CheckConfiguredDolphin()
     {
         string? versionText;
@@ -48,47 +36,17 @@ public sealed class DolphinVersionService(ILinuxProcessService processService) :
         if (string.IsNullOrWhiteSpace(dolphinLocation))
             return null;
 
-        // Flatpak: ask Flatpak instead of running Dolphin, which is faster and cannot pop a window.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PathManager.IsFlatpakDolphinFilePath(dolphinLocation))
-        {
-            var appId = PathManager.ExtractDolphinFlatpakAppId(dolphinLocation);
-            var flatpakResult = processService.Run("flatpak", $"info {appId}", out var flatpakStdOut, out _);
-            if (flatpakResult.IsFailure || flatpakResult.Value != 0)
-                return null;
+        // Invoke the configured Dolphin the way LaunchDolphin does, just with --version.
+        string stdOut;
+        string stdErr;
+        var result = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? processService.Run(dolphinLocation, "--version", out stdOut, out stdErr)
+            : processService.Run("/usr/bin/env", ["sh", "-c", "--", $"{dolphinLocation} --version"], out stdOut, out stdErr);
 
-            return FlatpakVersionLine.Match(flatpakStdOut) is { Success: true } match ? match.Groups["version"].Value : null;
-        }
-
-        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-        // On Unix the configured value can be a bare command rather than a path, so let a shell
-        // resolve it the same way LaunchDolphin does. On Windows it is always a real path.
-        var (fileName, arguments) = isWindows
-            ? (dolphinLocation, "--version")
-            : ("/usr/bin/env", $"sh -c -- \"{dolphinLocation} --version\"");
-
-        var result = processService.Run(fileName, arguments, out var stdOut, out var stdErr);
-        if (result.IsSuccess && result.Value == 0)
-        {
-            // Some builds print the version to stderr, so take whichever stream actually has something.
-            var output = string.IsNullOrWhiteSpace(stdOut) ? stdErr : stdOut;
-            if (DolphinVersion.GetStatus(output) != DolphinVersionStatus.Unknown)
-                return output;
-        }
-
-        // Dolphin on Windows is a GUI-subsystem exe: when Wheel Wizard itself was started from a
-        // console (a dev running it from a terminal), Dolphin attaches to that console and writes
-        // its version there instead of into our pipe. Fall back to the version baked into the binary.
-        return isWindows ? ReadWindowsBinaryVersion(dolphinLocation) : null;
-    }
-
-    private static string? ReadWindowsBinaryVersion(string dolphinLocation)
-    {
-        if (!File.Exists(dolphinLocation))
+        if (result.IsFailure || result.Value != 0)
             return null;
 
-        var binaryText = Encoding.ASCII.GetString(File.ReadAllBytes(Path.GetFullPath(dolphinLocation)));
-        var match = WindowsBinaryVersionPattern.Match(binaryText);
-        return match.Success ? match.Value : null;
+        // Some builds print the version to stderr, so take whichever stream actually has something.
+        return string.IsNullOrWhiteSpace(stdOut) ? stdErr : stdOut;
     }
 }

--- a/WheelWizard/Features/DolphinInstaller/DolphinVersionService.cs
+++ b/WheelWizard/Features/DolphinInstaller/DolphinVersionService.cs
@@ -1,0 +1,94 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using WheelWizard.Services;
+
+namespace WheelWizard.DolphinInstaller;
+
+public interface IDolphinVersionService
+{
+    /// <summary>
+    /// Reads the version of the Dolphin the user has configured. Never throws: anything we cannot
+    /// read or recognize comes back as <see cref="DolphinVersionStatus.Unknown"/>.
+    /// </summary>
+    (DolphinVersionStatus Status, string? Version) CheckConfiguredDolphin();
+}
+
+public sealed class DolphinVersionService(ILinuxProcessService processService) : IDolphinVersionService
+{
+    private static readonly Regex FlatpakVersionLine = new(@"^\s*Version:\s*(?<version>.+)$", RegexOptions.Multiline);
+
+    /// <summary>
+    /// The HTTP user agent Dolphin bakes into its binary, e.g. "Dolphin/2606". Deliberately not the
+    /// looser "Dolphin 2606" window-title form: the binary also embeds changelog text mentioning
+    /// other versions ("Dolphin 5.0-12188"), and mistaking one of those for the installed version
+    /// would keep warning people who already updated.
+    /// </summary>
+    private static readonly Regex WindowsBinaryVersionPattern = new(@"Dolphin/[0-9][\w.\-]*", RegexOptions.Compiled);
+
+    public (DolphinVersionStatus Status, string? Version) CheckConfiguredDolphin()
+    {
+        string? versionText;
+        try
+        {
+            versionText = ReadVersionText(PathManager.DolphinFilePath);
+        }
+        catch
+        {
+            // Probing must never be the reason someone cannot launch.
+            versionText = null;
+        }
+
+        var status = DolphinVersion.GetStatus(versionText, out var foundVersion);
+        return (status, foundVersion);
+    }
+
+    private string? ReadVersionText(string dolphinLocation)
+    {
+        if (string.IsNullOrWhiteSpace(dolphinLocation))
+            return null;
+
+        // Flatpak: ask Flatpak instead of running Dolphin, which is faster and cannot pop a window.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PathManager.IsFlatpakDolphinFilePath(dolphinLocation))
+        {
+            var appId = PathManager.ExtractDolphinFlatpakAppId(dolphinLocation);
+            var flatpakResult = processService.Run("flatpak", $"info {appId}", out var flatpakStdOut, out _);
+            if (flatpakResult.IsFailure || flatpakResult.Value != 0)
+                return null;
+
+            return FlatpakVersionLine.Match(flatpakStdOut) is { Success: true } match ? match.Groups["version"].Value : null;
+        }
+
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        // On Unix the configured value can be a bare command rather than a path, so let a shell
+        // resolve it the same way LaunchDolphin does. On Windows it is always a real path.
+        var (fileName, arguments) = isWindows
+            ? (dolphinLocation, "--version")
+            : ("/usr/bin/env", $"sh -c -- \"{dolphinLocation} --version\"");
+
+        var result = processService.Run(fileName, arguments, out var stdOut, out var stdErr);
+        if (result.IsSuccess && result.Value == 0)
+        {
+            // Some builds print the version to stderr, so take whichever stream actually has something.
+            var output = string.IsNullOrWhiteSpace(stdOut) ? stdErr : stdOut;
+            if (DolphinVersion.GetStatus(output) != DolphinVersionStatus.Unknown)
+                return output;
+        }
+
+        // Dolphin on Windows is a GUI-subsystem exe: when Wheel Wizard itself was started from a
+        // console (a dev running it from a terminal), Dolphin attaches to that console and writes
+        // its version there instead of into our pipe. Fall back to the version baked into the binary.
+        return isWindows ? ReadWindowsBinaryVersion(dolphinLocation) : null;
+    }
+
+    private static string? ReadWindowsBinaryVersion(string dolphinLocation)
+    {
+        if (!File.Exists(dolphinLocation))
+            return null;
+
+        var binaryText = Encoding.ASCII.GetString(File.ReadAllBytes(Path.GetFullPath(dolphinLocation)));
+        var match = WindowsBinaryVersionPattern.Match(binaryText);
+        return match.Success ? match.Value : null;
+    }
+}

--- a/WheelWizard/Features/DolphinInstaller/DolphinVersionService.cs
+++ b/WheelWizard/Features/DolphinInstaller/DolphinVersionService.cs
@@ -39,10 +39,26 @@ public sealed class DolphinVersionService(ILinuxProcessService processService) :
         // Invoke the configured Dolphin the way LaunchDolphin does, just with --version.
         string stdOut;
         string stdErr;
-        var result = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? processService.Run(dolphinLocation, "--version", out stdOut, out stdErr)
-            : processService.Run("/usr/bin/env", ["sh", "-c", "--", $"{dolphinLocation} --version"], out stdOut, out stdErr);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var windowsResult = processService.Run(dolphinLocation, "--version", out stdOut, out stdErr);
+            return ReadOutput(windowsResult, stdOut, stdErr);
+        }
 
+        // a broken Qt platform configuration should not be what stops us from reading the version.
+        // + flatpak dolphin runs in its own environment, so passing it here should not reach it anyway.
+        List<string> arguments = [];
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !PathManager.IsFlatpakDolphinFilePath(dolphinLocation))
+            arguments.Add("QT_QPA_PLATFORM=xcb");
+
+        arguments.AddRange(["sh", "-c", "--", $"{dolphinLocation} --version"]);
+
+        var result = processService.Run("/usr/bin/env", arguments, out stdOut, out stdErr);
+        return ReadOutput(result, stdOut, stdErr);
+    }
+
+    private static string? ReadOutput(OperationResult<int> result, string stdOut, string stdErr)
+    {
         if (result.IsFailure || result.Value != 0)
             return null;
 

--- a/WheelWizard/Features/DolphinInstaller/LinuxDolphinInstaller.cs
+++ b/WheelWizard/Features/DolphinInstaller/LinuxDolphinInstaller.cs
@@ -7,6 +7,7 @@ public interface ILinuxDolphinInstaller
     bool IsFlatpakInstalled();
     Task<OperationResult> InstallFlatpak(IProgress<int>? progress = null);
     Task<OperationResult> InstallFlatpakDolphin(IProgress<int>? progress = null);
+    Task<OperationResult> UpdateFlatpakDolphin(string appId, IProgress<int>? progress = null);
 }
 
 public sealed class LinuxDolphinInstaller(ILinuxCommandEnvironment commandEnvironment, ILinuxProcessService processService)
@@ -17,9 +18,7 @@ public sealed class LinuxDolphinInstaller(ILinuxCommandEnvironment commandEnviro
         const string dolphinAppId = "org.DolphinEmu.dolphin-emu";
         var processResult = processService.Run("flatpak", "list --app --columns=application", out var stdOut, out _);
 
-        return processResult.IsSuccess && processResult.Value == 0 && stdOut
-                .Split('\n')
-                .Any(line => line == dolphinAppId);
+        return processResult.IsSuccess && processResult.Value == 0 && stdOut.Split('\n').Any(line => line == dolphinAppId);
     }
 
     public bool IsDolphinInstalledNative()
@@ -104,5 +103,23 @@ public sealed class LinuxDolphinInstaller(ILinuxCommandEnvironment commandEnviro
 
         var launchResult = await processService.LaunchAndStopAsync("flatpak", "run org.DolphinEmu.dolphin-emu", TimeSpan.FromSeconds(4));
         return launchResult.IsFailure ? launchResult.Error : Ok();
+    }
+
+    public async Task<OperationResult> UpdateFlatpakDolphin(string appId, IProgress<int>? progress = null)
+    {
+        if (!IsFlatpakInstalled())
+            return Fail("Flatpak is not available, so Dolphin cannot be updated automatically.");
+
+        // No installation scope flag on purpose: Flatpak resolves whichever installation actually
+        // holds the app. A system-wide install may still refuse without elevation, which surfaces
+        // as a non-zero exit code and lets the caller fall back to the download page.
+        var updateResult = await processService.RunWithProgressAsync("flatpak", $"update -y {appId}", progress);
+        if (updateResult.IsFailure)
+            return updateResult.Error;
+
+        if (updateResult.Value != 0)
+            return Fail($"Dolphin update failed with exit code {updateResult.Value}.");
+
+        return Ok();
     }
 }

--- a/WheelWizard/Features/DolphinInstaller/LinuxProcessService.cs
+++ b/WheelWizard/Features/DolphinInstaller/LinuxProcessService.cs
@@ -6,6 +6,7 @@ namespace WheelWizard.DolphinInstaller;
 public interface ILinuxProcessService
 {
     OperationResult<int> Run(string fileName, string arguments, out string stdOut, out string stdErr);
+    OperationResult<int> Run(string fileName, IEnumerable<string> argumentList, out string stdOut, out string stdErr);
     OperationResult<int> Run(string fileName, string arguments);
     Task<OperationResult<int>> RunWithProgressAsync(string fileName, string arguments, IProgress<int>? progress = null);
     Task<OperationResult> LaunchAndStopAsync(string fileName, string arguments, TimeSpan duration);
@@ -15,20 +16,30 @@ public sealed class LinuxProcessService : ILinuxProcessService
 {
     public OperationResult<int> Run(string fileName, string arguments, out string stdOut, out string stdErr)
     {
+        var processInfo = new ProcessStartInfo { FileName = fileName, Arguments = arguments };
+        return Run(processInfo, $"{fileName} {arguments}", out stdOut, out stdErr);
+    }
+
+    public OperationResult<int> Run(string fileName, IEnumerable<string> argumentList, out string stdOut, out string stdErr)
+    {
+        var processInfo = new ProcessStartInfo { FileName = fileName };
+        foreach (var argument in argumentList)
+            processInfo.ArgumentList.Add(argument);
+
+        return Run(processInfo, $"{fileName} {string.Join(' ', processInfo.ArgumentList)}", out stdOut, out stdErr);
+    }
+
+    private static OperationResult<int> Run(ProcessStartInfo processInfo, string commandText, out string stdOut, out string stdErr)
+    {
         var localStdOut = "";
         var localStdErr = "";
         var result = TryCatch(
             () =>
             {
-                var processInfo = new ProcessStartInfo
-                {
-                    FileName = fileName,
-                    Arguments = arguments,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                };
+                processInfo.RedirectStandardOutput = true;
+                processInfo.RedirectStandardError = true;
+                processInfo.UseShellExecute = false;
+                processInfo.CreateNoWindow = true;
 
                 using var process = Process.Start(processInfo);
                 if (process == null)
@@ -39,7 +50,7 @@ public sealed class LinuxProcessService : ILinuxProcessService
                 process.WaitForExit();
                 return process.ExitCode;
             },
-            $"Failed to run process: {fileName} {arguments}"
+            $"Failed to run process: {commandText}"
         );
 
         stdOut = localStdOut;

--- a/WheelWizard/Features/Settings/SettingsManager.cs
+++ b/WheelWizard/Features/Settings/SettingsManager.cs
@@ -23,11 +23,7 @@ public class SettingsManager : ISettingsManager
     private double _internalScale = -1.0;
 
     #region Constructor
-    public SettingsManager(
-        IWhWzSettingManager whWzSettingManager,
-        IDolphinSettingManager dolphinSettingManager,
-        IFileSystem fileSystem
-    )
+    public SettingsManager(IWhWzSettingManager whWzSettingManager, IDolphinSettingManager dolphinSettingManager, IFileSystem fileSystem)
     {
         _whWzSettingManager = whWzSettingManager;
         _dolphinSettingManager = dolphinSettingManager;
@@ -90,7 +86,10 @@ public class SettingsManager : ISettingsManager
                     return false;
 
                 // `~/.dolphin-emu` would be used if it exists
-                if (!PathManager.IsFlatpakDolphinFilePath(dolphinLocation) && _fileSystem.Directory.Exists(PathManager.LinuxDolphinLegacyFolderPath))
+                if (
+                    !PathManager.IsFlatpakDolphinFilePath(dolphinLocation)
+                    && _fileSystem.Directory.Exists(PathManager.LinuxDolphinLegacyFolderPath)
+                )
                     return false;
 
                 return true;

--- a/WheelWizard/Resources/Languages/en.yml
+++ b/WheelWizard/Resources/Languages/en.yml
@@ -108,6 +108,7 @@ en:
   action:
     play: "Play"
     play_offline: "Play Offline"
+    play_anyway: "Play anyway"
     install: "Install"
     update: "Update"
     import: "Import"
@@ -241,6 +242,7 @@ en:
     installing_rr: "Installing Retro Rewind"
     installing_rr_first_time: "Installing Retro Rewind for the first time"
     installing_dolphin: "Installing Dolphin Emulator"
+    updating_dolphin: "Updating Dolphin Emulator"
     this_may_take_a_while: "This may take a while depending on your internet connection."
     applying_converted_mod: "Applying converted mod"
     combining_files: "Combining files"
@@ -275,6 +277,12 @@ en:
         If you don't know what all of this means, just click yes :)
 
         Dolphin Emulator folder found. Would you like to use this folder?
+    dolphin_outdated:
+      title: "Your Dolphin Emulator is out of date"
+      extra: |
+        This version of Dolphin ({$1}) has a known security issue where malicious game files, mods, or cheating online players can infect your PC with malware.
+
+        Update to {$2} or newer to be safe.
     dolphin_program_found:
       title: "Dolphin Emulator Found"
       extra: |
@@ -444,6 +452,7 @@ en:
     created_duplicate: "Created duplicate of '{$1}'"
     created_duplicates_miis: "Created {$1} duplicate Miis"
     profile_set_primary: "Set profile as primary"
+    dolphin_updated: "Dolphin Emulator has been updated"
   snackbar_error:
     mii_failure_deserialize: "Failed to deserialize Mii '{$1}'"
     mii_failure_update: "Failed to update Mii '{$1}'"

--- a/WheelWizard/Resources/Languages/en.yml
+++ b/WheelWizard/Resources/Languages/en.yml
@@ -340,6 +340,12 @@ en:
     dolphin_not_found:
       title: "Dolphin Emulator Folder Not Found"
       extra: "Dolphin Emulator folder not automatically found. Please try and find the folder manually, click 'help' for more information."
+    dolphin_version_unverified:
+      title: "Could not verify your Dolphin Emulator version"
+      extra: |
+        Wheel Wizard could not read the version of the Dolphin Emulator you have configured, so it cannot tell whether it has the security fixes.
+
+        Please check yourself that you are on {$1} or newer. Older versions have a known security issue where malicious game files, mods, or cheating online players can infect your PC with malware.
     dolphin_tool_selected:
       title: "Wrong Dolphin executable selected"
       extra: "You selected DolphinTool.exe. Please choose Dolphin.exe (the Dolphin emulator executable) instead."

--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -125,18 +125,22 @@ public static class DolphinLaunchHelper
         return fixedFlatpakDolphinLocation;
     }
 
-    /// <summary>
-    /// Blocks the launch when the configured Dolphin is known to be older than the version that fixed
-    /// the disc-image parsing vulnerabilities, and returns whether we should carry on launching.
-    /// </summary>
-    private static async Task<bool> ConfirmDolphinVersionAsync()
+    private static async Task<(DolphinVersionStatus Status, string? Version)> CheckDolphinVersionAsync()
     {
         var versionService = App.Services.GetRequiredService<IDolphinVersionService>();
 
         // Reading the version can mean spawning a process, so keep it off the UI thread.
-        var (status, version) = await Task.Run(versionService.CheckConfiguredDolphin);
+        return await Task.Run(versionService.CheckConfiguredDolphin);
+    }
+
+    /// <summary>
+    /// Checks whether the configured Dolphin can be used before callers perform launch preparation.
+    /// </summary>
+    public static async Task<OperationResult> PreflightDolphinVersionAsync()
+    {
+        var (status, version) = await CheckDolphinVersionAsync();
         if (status == DolphinVersionStatus.Supported)
-            return true;
+            return Ok();
 
         if (status == DolphinVersionStatus.Unknown)
         {
@@ -147,7 +151,7 @@ public static class DolphinLaunchHelper
                 .SetTitleText(t("message_warning.dolphin_version_unverified.title"))
                 .SetInfoText(t("message_warning.dolphin_version_unverified.extra", DolphinVersion.MinimumDisplayText))
                 .ShowDialog();
-            return true;
+            return Ok();
         }
 
         var popup = new YesNoWindow()
@@ -159,12 +163,12 @@ public static class DolphinLaunchHelper
         if (await popup.AwaitAnswer())
         {
             await StartDolphinUpdateAsync();
-            return false;
+            return Fail("Dolphin launch did not proceed because an update was requested.");
         }
 
         // Dismissing the popup is not the same as choosing to play anyway, so only an explicit
         // click on the red button gets through.
-        return popup.NoButtonClicked;
+        return popup.NoButtonClicked ? Ok() : Fail("Dolphin launch was cancelled.");
     }
 
     /// <summary>
@@ -208,10 +212,15 @@ public static class DolphinLaunchHelper
     }
 
     // Make sure all file arguments are absolute paths
-    public static async Task LaunchDolphin(string arguments = "", bool shellExecute = false)
+    public static async Task<OperationResult> LaunchDolphin(
+        string arguments = "",
+        bool shellExecute = false,
+        OperationResult? versionPreflightResult = null
+    )
     {
-        if (!await ConfirmDolphinVersionAsync())
-            return;
+        versionPreflightResult ??= await PreflightDolphinVersionAsync();
+        if (versionPreflightResult.IsFailure)
+            return versionPreflightResult;
 
         try
         {
@@ -247,6 +256,7 @@ public static class DolphinLaunchHelper
             }
 
             Process.Start(startInfo);
+            return Ok();
         }
         catch (Exception ex)
         {
@@ -255,6 +265,7 @@ public static class DolphinLaunchHelper
                 .SetTitleText("Failed to launch Dolphin")
                 .SetInfoText($"Reason: {ex.Message}")
                 .Show();
+            return new OperationError { Message = $"Failed to launch Dolphin: {ex.Message}", Exception = ex };
         }
     }
 }

--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -1,14 +1,19 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using WheelWizard.DolphinInstaller;
 using WheelWizard.Helpers;
 using WheelWizard.Settings;
+using WheelWizard.Views;
 using WheelWizard.Views.Popups.Generic;
+using Button = WheelWizard.Views.Components.Button;
 
 namespace WheelWizard.Services.Launcher.Helpers;
 
 public static class DolphinLaunchHelper
 {
+    private const string DolphinDownloadUrl = "https://dolphin-emu.org/download/";
+
     private static ISettingsManager Settings => SettingsRuntime.Current;
 
     public static void KillDolphin() //dont tell PETA
@@ -81,22 +86,9 @@ public static class DolphinLaunchHelper
         return false;
     }
 
-    private static string ExtractDolphinAppId(string flatpakDolphinLocation)
-    {
-        var defaultAppId = "org.DolphinEmu.dolphin-emu";
-
-        if (string.IsNullOrWhiteSpace(flatpakDolphinLocation))
-        {
-            return defaultAppId;
-        }
-
-        var matches = Regex.Matches(flatpakDolphinLocation, @"(?i)\b[a-z][a-z0-9]*(?:\.[a-z_][a-z0-9_]*){1,}\.[a-z_][a-z0-9_-]*\b");
-        return matches.Count == 0 ? defaultAppId : matches[^1].Value;
-    }
-
     private static string FixFlatpakDolphinPermissions(string flatpakDolphinLocation)
     {
-        var dolphinAppId = ExtractDolphinAppId(flatpakDolphinLocation);
+        var dolphinAppId = PathManager.ExtractDolphinFlatpakAppId(flatpakDolphinLocation);
         var fixedFlatpakDolphinLocation = flatpakDolphinLocation;
         void AddFilesystemPerm(string newFilesystemPerm, string mode = "")
         {
@@ -133,9 +125,82 @@ public static class DolphinLaunchHelper
         return fixedFlatpakDolphinLocation;
     }
 
-    // Make sure all file arguments are absolute paths
-    public static void LaunchDolphin(string arguments = "", bool shellExecute = false)
+    /// <summary>
+    /// Blocks the launch when the configured Dolphin is known to be older than the version that fixed
+    /// the disc-image parsing vulnerabilities, and returns whether we should carry on launching.
+    /// </summary>
+    private static async Task<bool> ConfirmDolphinVersionAsync()
     {
+        var versionService = App.Services.GetRequiredService<IDolphinVersionService>();
+
+        // Reading the version can mean spawning a process, so keep it off the UI thread.
+        var (status, version) = await Task.Run(versionService.CheckConfiguredDolphin);
+        if (status != DolphinVersionStatus.Outdated)
+            return true;
+
+        var popup = new YesNoWindow()
+            .SetButtonVariants(Button.ButtonsVariantType.Primary, Button.ButtonsVariantType.Danger)
+            .SetButtonText(t("action.update"), t("action.play_anyway"))
+            .SetMainText(t("question.dolphin_outdated.title"))
+            .SetExtraText(t("question.dolphin_outdated.extra", version ?? t("state.unknown"), DolphinVersion.MinimumDisplayText));
+
+        if (await popup.AwaitAnswer())
+        {
+            await StartDolphinUpdateAsync();
+            return false;
+        }
+
+        // Dismissing the popup is not the same as choosing to play anyway, so only an explicit
+        // click on the red button gets through.
+        return popup.NoButtonClicked;
+    }
+
+    /// <summary>
+    /// Updates a Flatpak Dolphin in place, because there we actually can. Every other install shape
+    /// just gets pointed at the download page.
+    /// </summary>
+    private static async Task StartDolphinUpdateAsync()
+    {
+        var dolphinLocation = Settings.Get<string>(Settings.DOLPHIN_LOCATION);
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || !PathManager.IsFlatpakDolphinFilePath(dolphinLocation))
+        {
+            ViewUtils.OpenLink(DolphinDownloadUrl);
+            return;
+        }
+
+        var installer = App.Services.GetRequiredService<ILinuxDolphinInstaller>();
+        var progressWindow = new ProgressWindow(t("progress.updating_dolphin"));
+        progressWindow.Show();
+
+        OperationResult updateResult;
+        try
+        {
+            var progress = new Progress<int>(percentage => progressWindow.UpdateProgress(percentage));
+            updateResult = await installer.UpdateFlatpakDolphin(PathManager.ExtractDolphinFlatpakAppId(dolphinLocation), progress);
+        }
+        finally
+        {
+            progressWindow.Close();
+        }
+
+        if (updateResult.IsSuccess)
+        {
+            ViewUtils.ShowSnackbar(t("snackbar_success.dolphin_updated"));
+        }
+        else
+        {
+            // Nothing we can do about it from here, so hand them the manual route.
+            ViewUtils.ShowSnackbar(updateResult.Error.Message, ViewUtils.SnackbarType.Danger);
+            ViewUtils.OpenLink(DolphinDownloadUrl);
+        }
+    }
+
+    // Make sure all file arguments are absolute paths
+    public static async Task LaunchDolphin(string arguments = "", bool shellExecute = false)
+    {
+        if (!await ConfirmDolphinVersionAsync())
+            return;
+
         try
         {
             var startInfo = new ProcessStartInfo();

--- a/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/DolphinLaunchHelper.cs
@@ -135,8 +135,20 @@ public static class DolphinLaunchHelper
 
         // Reading the version can mean spawning a process, so keep it off the UI thread.
         var (status, version) = await Task.Run(versionService.CheckConfiguredDolphin);
-        if (status != DolphinVersionStatus.Outdated)
+        if (status == DolphinVersionStatus.Supported)
             return true;
+
+        if (status == DolphinVersionStatus.Unknown)
+        {
+            // We could not read a version, so we have nothing to accuse them of. Say exactly that,
+            // hand the check over to them, and let them play.
+            await new MessageBoxWindow()
+                .SetMessageType(MessageBoxWindow.MessageType.Warning)
+                .SetTitleText(t("message_warning.dolphin_version_unverified.title"))
+                .SetInfoText(t("message_warning.dolphin_version_unverified.extra", DolphinVersion.MinimumDisplayText))
+                .ShowDialog();
+            return true;
+        }
 
         var popup = new YesNoWindow()
             .SetButtonVariants(Button.ButtonsVariantType.Primary, Button.ButtonsVariantType.Danger)

--- a/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
@@ -10,6 +10,11 @@ public static class MiiChannelLaunchHelper
 
     public static async Task LaunchMiiChannel()
     {
+        // Check first so a blocked launch does not enable the virtual Wii Remote.
+        var preflightResult = await DolphinLaunchHelper.PreflightDolphinVersionAsync();
+        if (preflightResult.IsFailure)
+            return;
+
         WiiMoteSettings.EnableVirtualWiiMote();
         var miiChannelExists = File.Exists(MiiChannelPath);
         ;
@@ -35,6 +40,9 @@ public static class MiiChannelLaunchHelper
         }
 
         if (miiChannelExists)
-            await DolphinLaunchHelper.LaunchDolphin($"-b {EnvHelper.QuotePath(Path.GetFullPath(MiiChannelPath))}");
+            await DolphinLaunchHelper.LaunchDolphin(
+                $"-b {EnvHelper.QuotePath(Path.GetFullPath(MiiChannelPath))}",
+                versionPreflightResult: preflightResult
+            );
     }
 }

--- a/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
+++ b/WheelWizard/Services/Launcher/Helpers/MiiChannelLaunchHelper.cs
@@ -35,6 +35,6 @@ public static class MiiChannelLaunchHelper
         }
 
         if (miiChannelExists)
-            DolphinLaunchHelper.LaunchDolphin($"-b {EnvHelper.QuotePath(Path.GetFullPath(MiiChannelPath))}");
+            await DolphinLaunchHelper.LaunchDolphin($"-b {EnvHelper.QuotePath(Path.GetFullPath(MiiChannelPath))}");
     }
 }

--- a/WheelWizard/Services/Launcher/RrBetaLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrBetaLauncher.cs
@@ -55,7 +55,7 @@ public class RrBetaLauncher : ILauncher
 
             RetroRewindLaunchHelper.GenerateLaunchJson(PathManager.RrBetaXmlFilePath);
             var dolphinLaunchType = _settingsManager.Get<bool>(_settingsManager.LAUNCH_WITH_DOLPHIN) ? "" : "-b";
-            DolphinLaunchHelper.LaunchDolphin(
+            await DolphinLaunchHelper.LaunchDolphin(
                 $"{dolphinLaunchType} -e {EnvHelper.QuotePath(Path.GetFullPath(RrLaunchJsonFilePath))} --config=Dolphin.Core.EnableCheats=False --config=Achievements.Achievements.Enabled=False"
             );
             return Ok();

--- a/WheelWizard/Services/Launcher/RrBetaLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrBetaLauncher.cs
@@ -32,6 +32,11 @@ public class RrBetaLauncher : ILauncher
     {
         try
         {
+            // Check first so a blocked launch does not kill Dolphin or prepare patches.
+            var preflightResult = await DolphinLaunchHelper.PreflightDolphinVersionAsync();
+            if (preflightResult.IsFailure)
+                return preflightResult.Error;
+
             DolphinLaunchHelper.KillDolphin();
             if (WiiMoteSettings.IsForceSettingsEnabled())
                 WiiMoteSettings.DisableVirtualWiiMote();
@@ -55,9 +60,13 @@ public class RrBetaLauncher : ILauncher
 
             RetroRewindLaunchHelper.GenerateLaunchJson(PathManager.RrBetaXmlFilePath);
             var dolphinLaunchType = _settingsManager.Get<bool>(_settingsManager.LAUNCH_WITH_DOLPHIN) ? "" : "-b";
-            await DolphinLaunchHelper.LaunchDolphin(
-                $"{dolphinLaunchType} -e {EnvHelper.QuotePath(Path.GetFullPath(RrLaunchJsonFilePath))} --config=Dolphin.Core.EnableCheats=False --config=Achievements.Achievements.Enabled=False"
+            var dolphinLaunchResult = await DolphinLaunchHelper.LaunchDolphin(
+                $"{dolphinLaunchType} -e {EnvHelper.QuotePath(Path.GetFullPath(RrLaunchJsonFilePath))} --config=Dolphin.Core.EnableCheats=False --config=Achievements.Achievements.Enabled=False",
+                versionPreflightResult: preflightResult
             );
+            if (dolphinLaunchResult.IsFailure)
+                return dolphinLaunchResult.Error;
+
             return Ok();
         }
         catch (Exception ex)

--- a/WheelWizard/Services/Launcher/RrLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrLauncher.cs
@@ -36,6 +36,11 @@ public class RrLauncher : ILauncher
             if (!File.Exists(PathManager.GameFilePath))
                 return Fail(t("message_warning.not_find_game.extra"));
 
+            // Check first so a blocked launch does not kill Dolphin or prepare patches.
+            var preflightResult = await DolphinLaunchHelper.PreflightDolphinVersionAsync();
+            if (preflightResult.IsFailure)
+                return preflightResult.Error;
+
             DolphinLaunchHelper.KillDolphin();
             if (WiiMoteSettings.IsForceSettingsEnabled())
                 WiiMoteSettings.DisableVirtualWiiMote();
@@ -56,9 +61,13 @@ public class RrLauncher : ILauncher
 
             RetroRewindLaunchHelper.GenerateLaunchJson();
             var dolphinLaunchType = _settingsManager.Get<bool>(_settingsManager.LAUNCH_WITH_DOLPHIN) ? "" : "-b";
-            await DolphinLaunchHelper.LaunchDolphin(
-                $"{dolphinLaunchType} -e {EnvHelper.QuotePath(Path.GetFullPath(RrLaunchJsonFilePath))} --config=Dolphin.Core.EnableCheats=False --config=Achievements.Achievements.Enabled=False"
+            var dolphinLaunchResult = await DolphinLaunchHelper.LaunchDolphin(
+                $"{dolphinLaunchType} -e {EnvHelper.QuotePath(Path.GetFullPath(RrLaunchJsonFilePath))} --config=Dolphin.Core.EnableCheats=False --config=Achievements.Achievements.Enabled=False",
+                versionPreflightResult: preflightResult
             );
+            if (dolphinLaunchResult.IsFailure)
+                return dolphinLaunchResult.Error;
+
             return Ok();
         }
         catch (Exception ex)

--- a/WheelWizard/Services/Launcher/RrLauncher.cs
+++ b/WheelWizard/Services/Launcher/RrLauncher.cs
@@ -56,7 +56,7 @@ public class RrLauncher : ILauncher
 
             RetroRewindLaunchHelper.GenerateLaunchJson();
             var dolphinLaunchType = _settingsManager.Get<bool>(_settingsManager.LAUNCH_WITH_DOLPHIN) ? "" : "-b";
-            DolphinLaunchHelper.LaunchDolphin(
+            await DolphinLaunchHelper.LaunchDolphin(
                 $"{dolphinLaunchType} -e {EnvHelper.QuotePath(Path.GetFullPath(RrLaunchJsonFilePath))} --config=Dolphin.Core.EnableCheats=False --config=Achievements.Achievements.Enabled=False"
             );
             return Ok();

--- a/WheelWizard/Services/PathManager.cs
+++ b/WheelWizard/Services/PathManager.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using Serilog;
 using WheelWizard.Helpers;
 using WheelWizard.Settings;
@@ -679,6 +680,20 @@ public static class PathManager
         // Because we need this prefix for the permission workarounds, we just expect it to start with "flatpak run"
         var flatpakRunCommand = "flatpak run";
         return filePath.StartsWith(flatpakRunCommand, StringComparison.Ordinal);
+    }
+
+    public const string DefaultDolphinFlatpakAppId = "org.DolphinEmu.dolphin-emu";
+
+    /// <summary>
+    /// Pulls the app ID out of a "flatpak run ..." command, so custom or forked Dolphin Flatpaks keep working.
+    /// </summary>
+    public static string ExtractDolphinFlatpakAppId(string flatpakDolphinLocation)
+    {
+        if (string.IsNullOrWhiteSpace(flatpakDolphinLocation))
+            return DefaultDolphinFlatpakAppId;
+
+        var matches = Regex.Matches(flatpakDolphinLocation, @"(?i)\b[a-z][a-z0-9]*(?:\.[a-z_][a-z0-9_]*){1,}\.[a-z_][a-z0-9_-]*\b");
+        return matches.Count == 0 ? DefaultDolphinFlatpakAppId : matches[^1].Value;
     }
 
     private static string GetContainingBaseDirectorySafe(string path)

--- a/WheelWizard/Views/Pages/HomePage.axaml.cs
+++ b/WheelWizard/Views/Pages/HomePage.axaml.cs
@@ -99,9 +99,9 @@ public partial class HomePage : UserControlBase
         UpdateActionButton();
     }
 
-    private void DolphinButton_OnClick(object? sender, RoutedEventArgs e)
+    private async void DolphinButton_OnClick(object? sender, RoutedEventArgs e)
     {
-        DolphinLaunchHelper.LaunchDolphin();
+        await DolphinLaunchHelper.LaunchDolphin();
         DisableAllButtonsTemporarily();
     }
 

--- a/WheelWizard/Views/Popups/DevToolWindow.axaml.cs
+++ b/WheelWizard/Views/Popups/DevToolWindow.axaml.cs
@@ -59,7 +59,8 @@ public partial class DevToolWindow : PopupContent, IRepeatedTaskListener
 
     private void ClearCache_OnClick(object sender, RoutedEventArgs e) => ((MemoryCache)Cache).Clear();
 
-    private void MiiChannel_OnClick(object? sender, RoutedEventArgs e) => DolphinLaunchHelper.LaunchDolphin(" -b -n 0001000248414341");
+    private async void MiiChannel_OnClick(object? sender, RoutedEventArgs e) =>
+        await DolphinLaunchHelper.LaunchDolphin(" -b -n 0001000248414341");
 
     #region Popup Tests
 

--- a/WheelWizard/Views/Popups/Generic/YesNoWindow.axaml.cs
+++ b/WheelWizard/Views/Popups/Generic/YesNoWindow.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Threading;
+using WheelWizard.Views.Components;
 using WheelWizard.Views.Popups.Base;
 
 namespace WheelWizard.Views.Popups.Generic;
@@ -8,6 +9,13 @@ namespace WheelWizard.Views.Popups.Generic;
 public partial class YesNoWindow : PopupContent
 {
     public bool Result { get; private set; } = false;
+
+    /// <summary>
+    /// Whether the user actually picked "no", as opposed to dismissing the window. Both leave
+    /// <see cref="Result"/> false, but a caller that treats "no" as a deliberate choice needs to tell them apart.
+    /// </summary>
+    public bool NoButtonClicked { get; private set; } = false;
+
     private TaskCompletionSource<bool>? _tcs;
 
     public YesNoWindow()
@@ -41,6 +49,13 @@ public partial class YesNoWindow : PopupContent
         return this;
     }
 
+    public YesNoWindow SetButtonVariants(Button.ButtonsVariantType yesVariant, Button.ButtonsVariantType noVariant)
+    {
+        YesButton.Variant = yesVariant;
+        NoButton.Variant = noVariant;
+        return this;
+    }
+
     private void yesButton_Click(object sender, RoutedEventArgs e)
     {
         Result = true;
@@ -48,7 +63,11 @@ public partial class YesNoWindow : PopupContent
         Close();
     }
 
-    private void noButton_Click(object sender, RoutedEventArgs e) => Close();
+    private void noButton_Click(object sender, RoutedEventArgs e)
+    {
+        NoButtonClicked = true;
+        Close();
+    }
 
     protected override void BeforeClose()
     {


### PR DESCRIPTION
## Purpose of this PR:
Force users to use newest dolphin version to avoid the Dolphin DSP-HLE Guest-to-Host RCE

###  How to Test:
Dolphin dolphin version 2606, link it to wheelwizard and try to launch your game, you should get a popup warning that this version is vulnerable, updating to 2606a should not give this popup

### What Has Been Changed:
A new DolphinVersionService has been created

### Related Issue Link:
none

## Checklist before merging
- [x] You have created relevant tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Dolphin version detection, identifying supported, outdated, and unrecognized installations.
  - Outdated Dolphin versions now prompt users to update or continue at their own risk.
  - Linux Flatpak installations can be updated in place with progress reporting.
  - Other installations provide a link to download the latest Dolphin version.
  - Added clearer update, warning, success, and “play anyway” messages.
- **Bug Fixes**
  - Dolphin launch actions now wait for update checks and launch completion before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->