### PR TITLE
fix(flatpak): Update Flatpak metainfo XML

### DIFF
--- a/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
+++ b/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
@@ -12,7 +12,7 @@
   <content_rating type="oars-1.0"/>
 
   <recommends>
-    <id version="2503" compare="ge">org.DolphinEmu.dolphin-emu</id>
+    <id version="2606a" compare="ge">org.DolphinEmu.dolphin-emu</id>
     <internet>always</internet>
   </recommends>
 
@@ -55,7 +55,7 @@
   </provides>
 
   <releases>
-    <release version="2.5.2" date="2026-08-27"/>>
+    <release version="2.5.2" date="2026-08-27"/>
     <release version="2.5.1" date="2026-08-24"/>
     <release version="2.5.0" date="2026-08-23"/>
     <release version="2.4.11" date="2026-07-09"/>


### PR DESCRIPTION
The latest commit which removed the duplicate entry seems to have messed up the XML formatting. I've fixed this and updated the `recommends` Dolphin version as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected formatting in the application’s release metadata.
* **Chores**
  * Updated the minimum supported emulator version recommendation to 2606a.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->