### PR TITLE
fix: restore macOS local build and publish from the csproj

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Local macOS build. Produces a .app bundle via macos/release-macos.sh.
+# https://avaloniaui.net/blog/the-definitive-guide-to-building-and-deploying-avalonia-applications-for-macos
+set -euo pipefail
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/macos/release-macos.sh" "$@"

--- a/macos/release-macos.sh
+++ b/macos/release-macos.sh
@@ -57,8 +57,9 @@ mkdir -p "$OUTPUT_DIR"
 # =============================================================================
 if [ "${SKIP_BUILD:-}" != "true" ]; then
     echo "[INFO] Building WheelWizard for $RID..."
-    cd "$WW_DIR"
-    dotnet publish -r "$RID" -c Release-macOS \
+    # Publish the project, not the solution: WheelWizard.sln only has
+    # Debug|Any CPU and Release|Any CPU, so -c Release-macOS fails against the .sln.
+    dotnet publish "$WW_DIR/WheelWizard/WheelWizard.csproj" -r "$RID" -c Release-macOS \
         /p:PublishSingleFile=true \
         /p:IncludeAllContentForSelfExtract=true \
         /p:IncludeNativeLibrariesForSelfExtract=true \
@@ -67,7 +68,6 @@ if [ "${SKIP_BUILD:-}" != "true" ]; then
         -p:UseAppHost=true \
         --self-contained true \
         -o "$OUTPUT_DIR/compiled/$RID"
-    cd "$SCRIPT_DIR"
 else
     echo "[INFO] Skipping build (SKIP_BUILD=true)"
 fi


### PR DESCRIPTION
## Purpose of this PR

The macOS release jobs added in #326 run `./macos/release-macos.sh` from the repo root. That script called `dotnet publish` with no project path, so the CLI picks up `WheelWizard.sln`. The solution only defines `Debug|Any CPU` and `Release|Any CPU`, so `-c Release-macOS` fails with MSB4126 and no `.app` / DMG is produced.

I hit this while building locally after that merge. The next `v*` tag would ship without macOS assets.

#326 also removed the root `build-mac.sh` that sat next to `build-linux.sh` / `build-win.bat`. Those Windows and Linux scripts are local-dev helpers (CI inlines `dotnet publish` for those platforms). Restoring a root `build-mac.sh` that delegates to `macos/release-macos.sh` brings macOS back in line.

## How to Test

On macOS, from the repo root:

```bash
./build-mac.sh
# or
./macos/release-macos.sh
```

Expected: a `.app` at `release/WheelWizard.app`, not:

```text
MSB4126: The specified solution configuration "Release-macOS|Any CPU" is invalid
```

Optional: `BUILD_ARCH=x64 ./build-mac.sh` for an Intel build.

CI: the `macos-arm64` and `macos-x64` jobs in `.github/workflows/release.yml` should get past the "Build .app bundle" step.

## What Has Been Changed

- `macos/release-macos.sh` now publishes `WheelWizard/WheelWizard.csproj` instead of the solution, matching the Windows and Linux `dotnet publish` steps in the release workflow.
- Restored root `build-mac.sh` as a local entry point that runs `macos/release-macos.sh` (same role as `build-linux.sh` / `build-win.bat`).

## Related Issue

None — found while building locally after #326.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS build entry point that can be run from any directory.
  * Improved build reliability by using an explicit project path and forwarding command-line options.

* **Bug Fixes**
  * Prevented macOS packaging builds from failing when started outside the project directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->