### PR TITLE
clean up old versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
           --self-contained true
           /p:UseAppHost=true
           /p:PublishSingleFile=true
-          /p:IncludeAllContentForSelfExtract=true
           /p:IncludeNativeLibrariesForSelfExtract=true
           /p:EnableCompressionInSingleFile=true
 
@@ -52,7 +51,6 @@ jobs:
           --self-contained true
           /p:UseAppHost=true
           /p:PublishSingleFile=true
-          /p:IncludeAllContentForSelfExtract=true
           /p:IncludeNativeLibrariesForSelfExtract=true
           /p:EnableCompressionInSingleFile=true
 
@@ -65,7 +63,6 @@ jobs:
           --self-contained true
           /p:UseAppHost=true
           /p:PublishSingleFile=true
-          /p:IncludeAllContentForSelfExtract=true
           /p:IncludeNativeLibrariesForSelfExtract=true
           /p:EnableCompressionInSingleFile=true
 

--- a/WheelWizard.Test/Features/BundleExtractionCleanupServiceTests.cs
+++ b/WheelWizard.Test/Features/BundleExtractionCleanupServiceTests.cs
@@ -1,0 +1,160 @@
+using System.IO.Abstractions;
+using Microsoft.Extensions.Logging;
+using Testably.Abstractions.Testing;
+using WheelWizard.AutoUpdating;
+
+namespace WheelWizard.Test.Features;
+
+public class BundleExtractionCleanupServiceTests
+{
+    private readonly MockFileSystem _fileSystem = new();
+    private readonly BundleExtractionCleanupService _service;
+
+    private readonly string _extractionRoot;
+    private readonly string _appDirectory;
+    private readonly string _currentExtraction;
+
+    public BundleExtractionCleanupServiceTests()
+    {
+        _service = new(_fileSystem, Substitute.For<ILogger<BundleExtractionCleanupService>>());
+
+        _extractionRoot = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine("/", "temp", ".net"));
+        _appDirectory = _fileSystem.Path.Combine(_extractionRoot, "WheelWizard");
+        _currentExtraction = _fileSystem.Path.Combine(_appDirectory, "current-bundle-id");
+    }
+
+    private string CreateExtraction(string appName, string bundleId)
+    {
+        var directory = _fileSystem.Path.Combine(_extractionRoot, appName, bundleId);
+        _fileSystem.Directory.CreateDirectory(directory);
+        _fileSystem.File.WriteAllText(_fileSystem.Path.Combine(directory, "libSomething.dll"), "native");
+        return directory;
+    }
+
+    private static string JoinSearchDirectories(params string[] directories) => string.Join(Path.PathSeparator, directories);
+
+    [Fact]
+    public void CleanupStaleExtractions_RemovesOtherVersions_ButKeepsCurrentOne()
+    {
+        CreateExtraction("WheelWizard", "current-bundle-id");
+        var oldA = CreateExtraction("WheelWizard", "old-bundle-a");
+        var oldB = CreateExtraction("WheelWizard", "old-bundle-b");
+
+        var removed = _service.CleanupStaleExtractions(_currentExtraction);
+
+        Assert.Equal(2, removed);
+        Assert.True(_fileSystem.Directory.Exists(_currentExtraction));
+        Assert.True(_fileSystem.File.Exists(_fileSystem.Path.Combine(_currentExtraction, "libSomething.dll")));
+        Assert.False(_fileSystem.Directory.Exists(oldA));
+        Assert.False(_fileSystem.Directory.Exists(oldB));
+    }
+
+    [Fact]
+    public void CleanupStaleExtractions_RemovesUpdateExecutableExtractions()
+    {
+        CreateExtraction("WheelWizard", "current-bundle-id");
+        CreateExtraction("WheelWizard_new", "downloaded-bundle-a");
+        CreateExtraction("WheelWizard_new", "downloaded-bundle-b");
+        var updateAppDirectory = _fileSystem.Path.Combine(_extractionRoot, "WheelWizard_new");
+
+        var removed = _service.CleanupStaleExtractions(_currentExtraction);
+
+        Assert.Equal(1, removed);
+        Assert.False(_fileSystem.Directory.Exists(updateAppDirectory));
+        Assert.True(_fileSystem.Directory.Exists(_currentExtraction));
+    }
+
+    [Fact]
+    public void CleanupStaleExtractions_LeavesOtherApplicationsAlone()
+    {
+        CreateExtraction("WheelWizard", "current-bundle-id");
+        var otherApp = CreateExtraction("SomeOtherApp", "some-bundle-id");
+        var similarName = CreateExtraction("WheelWizardTool", "some-bundle-id");
+
+        var removed = _service.CleanupStaleExtractions(_currentExtraction);
+
+        Assert.Equal(0, removed);
+        Assert.True(_fileSystem.Directory.Exists(otherApp));
+        Assert.True(_fileSystem.Directory.Exists(similarName));
+    }
+
+    [Fact]
+    public void CleanupStaleExtractions_ReturnsZero_WhenNothingExists()
+    {
+        var removed = _service.CleanupStaleExtractions(_currentExtraction);
+
+        Assert.Equal(0, removed);
+    }
+
+    [Fact]
+    public void CleanupStaleExtractions_AcceptsTrailingSeparatorForCurrentDirectory()
+    {
+        CreateExtraction("WheelWizard", "current-bundle-id");
+        var old = CreateExtraction("WheelWizard", "old-bundle");
+
+        var removed = _service.CleanupStaleExtractions(_currentExtraction + _fileSystem.Path.DirectorySeparatorChar);
+
+        Assert.Equal(1, removed);
+        Assert.True(_fileSystem.Directory.Exists(_currentExtraction));
+        Assert.False(_fileSystem.Directory.Exists(old));
+    }
+
+    [Fact]
+    public void ResolveExtractionDirectory_FindsExtractionDirectory_FromNativeSearchDirectories()
+    {
+        var executableDirectory = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine("/", "apps", "ww"));
+        var processPath = _fileSystem.Path.Combine(executableDirectory, "WheelWizard.exe");
+        var searchDirectories = JoinSearchDirectories(_currentExtraction + _fileSystem.Path.DirectorySeparatorChar, executableDirectory);
+
+        var resolved = _service.ResolveExtractionDirectory(processPath, searchDirectories);
+
+        Assert.Equal(_currentExtraction, resolved);
+    }
+
+    [Fact]
+    public void ResolveExtractionDirectory_ReturnsNull_WhenNotRunningFromBundle()
+    {
+        var executableDirectory = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine("/", "apps", "ww"));
+        var processPath = _fileSystem.Path.Combine(executableDirectory, "WheelWizard.exe");
+
+        Assert.Null(_service.ResolveExtractionDirectory(processPath, executableDirectory));
+        Assert.Null(_service.ResolveExtractionDirectory(processPath, null));
+        Assert.Null(_service.ResolveExtractionDirectory(null, _currentExtraction));
+    }
+
+    [Fact]
+    public void ResolveExtractionDirectory_IgnoresExecutableDirectory_EvenWhenParentMatchesAppName()
+    {
+        // e.g. C:\WheelWizard\WheelWizard\WheelWizard.exe must never be treated as an extraction folder
+        var executableDirectory = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine("/", "WheelWizard", "WheelWizard"));
+        var processPath = _fileSystem.Path.Combine(executableDirectory, "WheelWizard.exe");
+
+        var resolved = _service.ResolveExtractionDirectory(processPath, executableDirectory);
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void ResolveExtractionDirectory_ReturnsNull_WhenLayoutIsNotUnderDotNetFolder()
+    {
+        var executableDirectory = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine("/", "apps", "ww"));
+        var processPath = _fileSystem.Path.Combine(executableDirectory, "WheelWizard.exe");
+        var notAnExtraction = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine("/", "cache", "WheelWizard", "some-id"));
+
+        var resolved = _service.ResolveExtractionDirectory(processPath, JoinSearchDirectories(notAnExtraction, executableDirectory));
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void ResolveExtractionDirectory_ReturnsNull_WhenAppNameDoesNotMatch()
+    {
+        var executableDirectory = _fileSystem.Path.GetFullPath(_fileSystem.Path.Combine("/", "apps", "ww"));
+        var processPath = _fileSystem.Path.Combine(executableDirectory, "WheelWizard.exe");
+        var otherApp = _fileSystem.Path.Combine(_extractionRoot, "SomeOtherApp", "some-id");
+
+        var resolved = _service.ResolveExtractionDirectory(processPath, JoinSearchDirectories(otherApp, executableDirectory));
+
+        Assert.Null(resolved);
+    }
+}

--- a/WheelWizard/Features/AutoUpdating/AutoUpdatingExtensions.cs
+++ b/WheelWizard/Features/AutoUpdating/AutoUpdatingExtensions.cs
@@ -7,6 +7,7 @@ public static class AutoUpdatingExtensions
     public static IServiceCollection AddAutoUpdating(this IServiceCollection services)
     {
         services.AddSingleton<IAutoUpdaterSingletonService, AutoUpdaterSingletonService>();
+        services.AddSingleton<IBundleExtractionCleanupService, BundleExtractionCleanupService>();
 
         var implementationType = typeof(FallbackUpdatePlatform);
 #if WINDOWS

--- a/WheelWizard/Features/AutoUpdating/BundleExtractionCleanupService.cs
+++ b/WheelWizard/Features/AutoUpdating/BundleExtractionCleanupService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.IO.Abstractions;
 using Microsoft.Extensions.Logging;
 
@@ -54,6 +55,15 @@ public class BundleExtractionCleanupService(IFileSystem fileSystem, ILogger<Bund
                 }
 
                 logger.LogInformation("Running from single-file extraction folder: {Directory}", currentExtractionDirectory);
+
+                // Another (possibly older) WheelWizard instance might still be loading native libraries from its own
+                // extraction folder. Deleting that folder from under it could break it, so leave the cleanup to a later start.
+                if (IsAnotherInstanceRunning(processPath!))
+                {
+                    logger.LogDebug("Another WheelWizard instance is running, skipping extraction cleanup");
+                    return;
+                }
+
                 var removedCount = CleanupStaleExtractions(currentExtractionDirectory);
                 if (removedCount > 0)
                     logger.LogInformation("Removed {Count} stale single-file extraction folder(s)", removedCount);
@@ -140,6 +150,43 @@ public class BundleExtractionCleanupService(IFileSystem fileSystem, ILogger<Bund
         }
 
         return removedCount;
+    }
+
+    /// <summary>
+    /// Checks whether another process with the name of this executable (or its <c>_new</c> update counterpart) is running.
+    /// When the processes cannot be enumerated, this errs on the side of caution and reports <c>true</c>.
+    /// </summary>
+    private bool IsAnotherInstanceRunning(string processPath)
+    {
+        var appName = fileSystem.Path.GetFileNameWithoutExtension(processPath);
+        var currentProcessId = Environment.ProcessId;
+
+        foreach (var processName in new[] { appName, appName + UpdateExecutableSuffix })
+        {
+            Process[] processes;
+            try
+            {
+                processes = Process.GetProcessesByName(processName);
+            }
+            catch (Exception e)
+            {
+                logger.LogDebug(e, "Could not enumerate running processes named {ProcessName}", processName);
+                return true;
+            }
+
+            try
+            {
+                if (processes.Any(process => process.Id != currentProcessId))
+                    return true;
+            }
+            finally
+            {
+                foreach (var process in processes)
+                    process.Dispose();
+            }
+        }
+
+        return false;
     }
 
     private bool TryDeleteDirectory(string directory)

--- a/WheelWizard/Features/AutoUpdating/BundleExtractionCleanupService.cs
+++ b/WheelWizard/Features/AutoUpdating/BundleExtractionCleanupService.cs
@@ -1,0 +1,188 @@
+using System.IO.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace WheelWizard.AutoUpdating;
+
+public interface IBundleExtractionCleanupService
+{
+    /// <summary>
+    /// Removes the single-file extraction folders that were left behind by previous WheelWizard versions.
+    /// This runs in the background and never throws.
+    /// </summary>
+    Task CleanupStaleExtractionsAsync();
+}
+
+/// <summary>
+/// WheelWizard is published as a self-extracting single-file executable. The .NET host extracts the bundled native
+/// libraries to <c>&lt;base&gt;/.net/&lt;executable name&gt;/&lt;bundle id&gt;</c> (e.g. <c>%TEMP%\.net\WheelWizard\...</c>
+/// on Windows). Every release has a new bundle id, so every update leaves the previous extraction folder behind.
+/// The updater also downloads the new executable as <c>WheelWizard_new</c>, which gets its own extraction folder.
+/// This service deletes those stale folders while leaving the one used by the running process untouched.
+/// </summary>
+public class BundleExtractionCleanupService(IFileSystem fileSystem, ILogger<BundleExtractionCleanupService> logger)
+    : IBundleExtractionCleanupService
+{
+    /// <summary>
+    /// Suffix the updaters append to the downloaded executable (e.g. <c>WheelWizard_new.exe</c>).
+    /// </summary>
+    internal const string UpdateExecutableSuffix = "_new";
+
+    /// <summary>
+    /// Name of the folder the .NET host creates its extraction folders in.
+    /// </summary>
+    internal const string ExtractionRootName = ".net";
+
+    /// <summary>
+    /// The runtime property that contains the directories used to resolve native libraries. For a single-file
+    /// bundle with extracted native libraries, this includes the extraction directory of the running process.
+    /// </summary>
+    private const string NativeSearchDirectoriesProperty = "NATIVE_DLL_SEARCH_DIRECTORIES";
+
+    public Task CleanupStaleExtractionsAsync()
+    {
+        return Task.Run(() =>
+        {
+            try
+            {
+                var processPath = Environment.ProcessPath;
+                var nativeSearchDirectories = AppContext.GetData(NativeSearchDirectoriesProperty) as string;
+                var currentExtractionDirectory = ResolveExtractionDirectory(processPath, nativeSearchDirectories);
+                if (currentExtractionDirectory is null)
+                {
+                    logger.LogDebug("Not running from a self-extracted single-file bundle, skipping extraction cleanup");
+                    return;
+                }
+
+                logger.LogInformation("Running from single-file extraction folder: {Directory}", currentExtractionDirectory);
+                var removedCount = CleanupStaleExtractions(currentExtractionDirectory);
+                if (removedCount > 0)
+                    logger.LogInformation("Removed {Count} stale single-file extraction folder(s)", removedCount);
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning(e, "Failed to clean up stale single-file extraction folders");
+            }
+        });
+    }
+
+    /// <summary>
+    /// Finds the extraction directory of the running process based on the native library search directories.
+    /// Returns <c>null</c> when the process is not running from a self-extracted single-file bundle.
+    /// </summary>
+    public string? ResolveExtractionDirectory(string? processPath, string? nativeSearchDirectories)
+    {
+        if (string.IsNullOrWhiteSpace(processPath) || string.IsNullOrWhiteSpace(nativeSearchDirectories))
+            return null;
+
+        var appName = fileSystem.Path.GetFileNameWithoutExtension(processPath);
+        var executableDirectory = fileSystem.Path.GetDirectoryName(processPath);
+        if (string.IsNullOrWhiteSpace(appName) || string.IsNullOrWhiteSpace(executableDirectory))
+            return null;
+
+        foreach (var searchDirectory in nativeSearchDirectories.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = NormalizePath(searchDirectory);
+            if (candidate is null || PathEquals(candidate, executableDirectory))
+                continue;
+
+            // Expected layout: <base>/.net/<app name>/<bundle id>
+            var appDirectory = fileSystem.Path.GetDirectoryName(candidate);
+            var extractionRoot = appDirectory is null ? null : fileSystem.Path.GetDirectoryName(appDirectory);
+            if (appDirectory is null || extractionRoot is null)
+                continue;
+
+            if (!NameEquals(fileSystem.Path.GetFileName(appDirectory), appName))
+                continue;
+            if (!NameEquals(fileSystem.Path.GetFileName(extractionRoot), ExtractionRootName))
+                continue;
+
+            return candidate;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Deletes every extraction folder that belongs to this application except <paramref name="currentExtractionDirectory"/>,
+    /// as well as the extraction folders of the <c>_new</c> executable that the updater downloads.
+    /// </summary>
+    /// <returns>The number of folders that were removed.</returns>
+    public int CleanupStaleExtractions(string currentExtractionDirectory)
+    {
+        var current = NormalizePath(currentExtractionDirectory);
+        var appDirectory = current is null ? null : fileSystem.Path.GetDirectoryName(current);
+        var extractionRoot = appDirectory is null ? null : fileSystem.Path.GetDirectoryName(appDirectory);
+        if (current is null || appDirectory is null || extractionRoot is null)
+            return 0;
+
+        var removedCount = 0;
+
+        // Extraction folders of previous versions of this executable.
+        if (fileSystem.Directory.Exists(appDirectory))
+        {
+            foreach (var directory in fileSystem.Directory.EnumerateDirectories(appDirectory))
+            {
+                if (PathEquals(directory, current))
+                    continue;
+
+                if (TryDeleteDirectory(directory))
+                    removedCount++;
+            }
+        }
+
+        // Extraction folders of the downloaded update executable (e.g. WheelWizard_new).
+        var appName = fileSystem.Path.GetFileName(appDirectory);
+        var updateAppDirectory = fileSystem.Path.Combine(extractionRoot, appName + UpdateExecutableSuffix);
+        if (!PathEquals(updateAppDirectory, appDirectory) && fileSystem.Directory.Exists(updateAppDirectory))
+        {
+            if (TryDeleteDirectory(updateAppDirectory))
+                removedCount++;
+        }
+
+        return removedCount;
+    }
+
+    private bool TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            fileSystem.Directory.Delete(directory, recursive: true);
+            logger.LogDebug("Removed stale single-file extraction folder: {Directory}", directory);
+            return true;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Most likely still in use by another (older) WheelWizard process. The .NET host repairs
+            // partially deleted extraction folders on the next start, so this is safe to ignore.
+            logger.LogDebug(e, "Could not remove single-file extraction folder: {Directory}", directory);
+            return false;
+        }
+    }
+
+    private string? NormalizePath(string path)
+    {
+        try
+        {
+            var fullPath = fileSystem.Path.GetFullPath(path);
+            var trimmed = fullPath.TrimEnd(fileSystem.Path.DirectorySeparatorChar, fileSystem.Path.AltDirectorySeparatorChar);
+            return trimmed.Length == 0 ? fullPath : trimmed;
+        }
+        catch (Exception e) when (e is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return null;
+        }
+    }
+
+    private bool PathEquals(string left, string right)
+    {
+        var normalizedLeft = NormalizePath(left);
+        var normalizedRight = NormalizePath(right);
+        return normalizedLeft is not null && normalizedRight is not null && NameEquals(normalizedLeft, normalizedRight);
+    }
+
+    private static bool NameEquals(string left, string right)
+    {
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return string.Equals(left, right, comparison);
+    }
+}

--- a/WheelWizard/Views/App.axaml.cs
+++ b/WheelWizard/Views/App.axaml.cs
@@ -197,6 +197,10 @@ public class App : Application
     {
         try
         {
+            // Fire and forget: removing the extraction folders of previous versions can take a while
+            // and must never block (or fail) the startup of the application.
+            _ = Services.GetRequiredService<IBundleExtractionCleanupService>().CleanupStaleExtractionsAsync();
+
             var resourceInstaller = Services.GetRequiredService<IMiiRenderingResourceInstaller>();
             if (resourceInstaller.GetResolvedResourcePath().IsFailure)
             {

--- a/build-linux-arm64.bat
+++ b/build-linux-arm64.bat
@@ -1,1 +1,1 @@
-dotnet publish -r linux-arm64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeAllContentForSelfExtract=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true
+dotnet publish -r linux-arm64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true

--- a/build-linux-arm64.sh
+++ b/build-linux-arm64.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-dotnet publish -r linux-arm64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeAllContentForSelfExtract=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true
+dotnet publish -r linux-arm64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true

--- a/build-linux.bat
+++ b/build-linux.bat
@@ -1,1 +1,1 @@
-dotnet publish -r linux-x64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeAllContentForSelfExtract=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true
+dotnet publish -r linux-x64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-dotnet publish -r linux-x64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeAllContentForSelfExtract=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true
+dotnet publish -r linux-x64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true

--- a/build-win.bat
+++ b/build-win.bat
@@ -1,1 +1,1 @@
-dotnet publish -r win-x64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeAllContentForSelfExtract=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true
+dotnet publish -r win-x64 -c Release /p:UseAppHost=true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true /p:EnableCompressionInSingleFile=true --self-contained true

--- a/macos/release-macos.sh
+++ b/macos/release-macos.sh
@@ -61,7 +61,6 @@ if [ "${SKIP_BUILD:-}" != "true" ]; then
     # Debug|Any CPU and Release|Any CPU, so -c Release-macOS fails against the .sln.
     dotnet publish "$WW_DIR/WheelWizard/WheelWizard.csproj" -r "$RID" -c Release-macOS \
         /p:PublishSingleFile=true \
-        /p:IncludeAllContentForSelfExtract=true \
         /p:IncludeNativeLibrariesForSelfExtract=true \
         /p:EnableCompressionInSingleFile=true \
         /p:PublishReadyToRun=true \


### PR DESCRIPTION
## Purpose of this PR:
Originially ment as a fix for https://github.com/TeamWheelWizard/WheelWizard/issues/356 turned out we can reduce the app size dramatically


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup cleanup by removing stale temporary extraction folders from previous application versions.
  - Preserves the extraction directory currently in use and safely handles cleanup failures without interrupting startup.
  - Updated desktop release packaging to remove an unnecessary single-file publishing setting across supported platforms.

- **Tests**
  - Added coverage for stale extraction cleanup, active-directory preservation, update artifacts, platform path handling, and invalid layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->