### PR TITLE
offline play

### DIFF
--- a/WheelWizard.Test/Features/Recomp/RecompTests.cs
+++ b/WheelWizard.Test/Features/Recomp/RecompTests.cs
@@ -74,6 +74,46 @@ public class RecompTests
     }
 
     [Fact]
+    public void PayloadPolicy_LegacyStateWithoutModeKeepsDownloadingWhenTheServiceIsDown()
+    {
+        // Written by a host that predates the mode field: Retro Rewind is installed, so the host owns a
+        // verified payload copy and must be asked to download, never to skip or to bother the user.
+        var legacy = new RecompInstallState
+        {
+            SchemaVersion = 1,
+            SetupVersion = "0.2.25",
+            InstallDir = @"D:\Recomp",
+            RetroRewindInstalled = true,
+        };
+
+        Assert.False(RecompRetroWfcPayloadPolicy.NeedsServiceProbe(legacy, hasRetroRewindSource: true));
+        Assert.Equal(RecompRetroWfcPayloadDecision.Download, RecompRetroWfcPayloadPolicy.Decide(legacy, true, serviceReachable: false));
+    }
+
+    [Fact]
+    public void PayloadPolicy_OnlyAFreshRetroRewindBuildAsksTheUser()
+    {
+        var downloaded = new RecompInstallState { RetroWfcPayloadMode = "downloaded", RetroRewindInstalled = true };
+        var skipped = new RecompInstallState { RetroWfcPayloadMode = "skipped", RetroRewindInstalled = true };
+        var baseOnly = new RecompInstallState { RetroWfcPayloadMode = "", RetroRewindInstalled = false };
+
+        // Nothing to decide without a Retro Rewind source, and never a probe for a payload-bearing install.
+        Assert.False(RecompRetroWfcPayloadPolicy.NeedsServiceProbe(null, hasRetroRewindSource: false));
+        Assert.False(RecompRetroWfcPayloadPolicy.NeedsServiceProbe(downloaded, hasRetroRewindSource: true));
+        Assert.Equal(RecompRetroWfcPayloadDecision.Download, RecompRetroWfcPayloadPolicy.Decide(downloaded, true, serviceReachable: false));
+
+        // A skipped install stays offline while the service is down and upgrades when it is back.
+        Assert.True(RecompRetroWfcPayloadPolicy.NeedsServiceProbe(skipped, hasRetroRewindSource: true));
+        Assert.Equal(RecompRetroWfcPayloadDecision.Skip, RecompRetroWfcPayloadPolicy.Decide(skipped, true, serviceReachable: false));
+        Assert.Equal(RecompRetroWfcPayloadDecision.Download, RecompRetroWfcPayloadPolicy.Decide(skipped, true, serviceReachable: true));
+
+        // A fresh install and a base-only install both need a brand new Retro Rewind build.
+        Assert.Equal(RecompRetroWfcPayloadDecision.AskUser, RecompRetroWfcPayloadPolicy.Decide(null, true, serviceReachable: false));
+        Assert.Equal(RecompRetroWfcPayloadDecision.AskUser, RecompRetroWfcPayloadPolicy.Decide(baseOnly, true, serviceReachable: false));
+        Assert.Equal(RecompRetroWfcPayloadDecision.Download, RecompRetroWfcPayloadPolicy.Decide(null, true, serviceReachable: true));
+    }
+
+    [Fact]
     public void ProductsLine_IsReadBackAsTheProductStateItReports()
     {
         var parsed = RecompSetupOutputParser.Parse(

--- a/WheelWizard.Test/Features/Recomp/RecompTests.cs
+++ b/WheelWizard.Test/Features/Recomp/RecompTests.cs
@@ -32,6 +32,48 @@ public class RecompTests
     }
 
     [Fact]
+    public void SilentInstall_SkipsThePayloadOnlyWhenAskedTo()
+    {
+        var arguments = RecompSetupCommandBuilder.BuildSilentInstallArguments(
+            new()
+            {
+                GameFilePath = @"D:\Games\Mario Kart Wii.rvz",
+                InstallFolderPath = @"D:\WheelWizard\Recomp\Install",
+                RetroRewindFolderPath = @"D:\WheelWizard\RetroRewind6",
+                RetroWfcPayloadMode = RecompRetroWfcPayloadMode.Skip,
+            }
+        );
+
+        Assert.EndsWith("--retro-dir \"D:\\WheelWizard\\RetroRewind6\" --skip-retro-wfc-payload", arguments);
+        Assert.DoesNotContain("--download-retro-wfc-payload", arguments);
+    }
+
+    [Fact]
+    public void RepairProducts_PassesExactlyOnePayloadOption()
+    {
+        Assert.Equal(
+            "--repair-products --install-dir \"D:\\Recomp\" --retro-dir \"D:\\RetroRewind6\" --download-retro-wfc-payload --progress-json",
+            RecompSetupCommandBuilder.BuildRepairProductsArguments(@"D:\Recomp", @"D:\RetroRewind6")
+        );
+        Assert.Equal(
+            "--repair-products --install-dir \"D:\\Recomp\" --retro-dir \"D:\\RetroRewind6\" --skip-retro-wfc-payload --progress-json",
+            RecompSetupCommandBuilder.BuildRepairProductsArguments(@"D:\Recomp", @"D:\RetroRewind6", RecompRetroWfcPayloadMode.Skip)
+        );
+    }
+
+    [Fact]
+    public void InstallState_ReadsThePayloadModeTheSetupHostWrites()
+    {
+        var state = System.Text.Json.JsonSerializer.Deserialize<RecompInstallState>(
+            """{"SchemaVersion":1,"SetupVersion":"0.3.0","InstallDir":"D:\\Recomp","RetroWfcPayloadMode":"skipped"}""",
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true }
+        );
+
+        Assert.NotNull(state);
+        Assert.True(state.IsRetroWfcPayloadSkipped);
+    }
+
+    [Fact]
     public void ProductsLine_IsReadBackAsTheProductStateItReports()
     {
         var parsed = RecompSetupOutputParser.Parse(

--- a/WheelWizard/Features/Recomp/Domain/RecompInstallModels.cs
+++ b/WheelWizard/Features/Recomp/Domain/RecompInstallModels.cs
@@ -24,6 +24,28 @@ public class RecompInstallState
     public int? SchemaVersion { get; set; }
     public string? SetupVersion { get; set; }
     public string? InstallDir { get; set; }
+
+    /// <summary>
+    /// How the installed Retro Rewind product was built: <c>downloaded</c> when it embeds a Retro-WFC
+    /// payload, <c>skipped</c> when it was deliberately built without one, or empty for a base-only install.
+    /// </summary>
+    public string? RetroWfcPayloadMode { get; set; }
+
+    /// <summary>Whether the installed Retro Rewind product was built without a Retro-WFC payload.</summary>
+    public bool IsRetroWfcPayloadSkipped => string.Equals(RetroWfcPayloadMode, "skipped", StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// The Retro-WFC payload choice handed to the setup executable. The contract requires exactly one whenever a
+/// Retro Rewind source directory is passed.
+/// </summary>
+public enum RecompRetroWfcPayloadMode
+{
+    /// <summary>Let the setup host download the shared payload (<c>--download-retro-wfc-payload</c>).</summary>
+    Download,
+
+    /// <summary>Build Retro Rewind without the payload (<c>--skip-retro-wfc-payload</c>); online play is unavailable.</summary>
+    Skip,
 }
 
 /// <summary>
@@ -47,4 +69,10 @@ public sealed record RecompInstallRequest
     /// an installation that predates portable mode keeps its machine-local layout.
     /// </summary>
     public bool Portable { get; init; }
+
+    /// <summary>
+    /// The Retro-WFC payload choice for the Retro Rewind product. Only meaningful together with
+    /// <see cref="RetroRewindFolderPath"/>.
+    /// </summary>
+    public RecompRetroWfcPayloadMode RetroWfcPayloadMode { get; init; } = RecompRetroWfcPayloadMode.Download;
 }

--- a/WheelWizard/Features/Recomp/Domain/RecompInstallModels.cs
+++ b/WheelWizard/Features/Recomp/Domain/RecompInstallModels.cs
@@ -25,9 +25,14 @@ public class RecompInstallState
     public string? SetupVersion { get; set; }
     public string? InstallDir { get; set; }
 
+    /// <summary>Whether the setup host has produced the Retro Rewind product, as opposed to only the base game.</summary>
+    public bool RetroRewindInstalled { get; set; }
+
     /// <summary>
     /// How the installed Retro Rewind product was built: <c>downloaded</c> when it embeds a Retro-WFC
     /// payload, <c>skipped</c> when it was deliberately built without one, or empty for a base-only install.
+    /// A state written before this field existed leaves it <see langword="null"/>; see
+    /// <see cref="RecompRetroWfcPayloadPolicy"/> for how that is read.
     /// </summary>
     public string? RetroWfcPayloadMode { get; set; }
 

--- a/WheelWizard/Features/Recomp/RecompExtensions.cs
+++ b/WheelWizard/Features/Recomp/RecompExtensions.cs
@@ -31,6 +31,7 @@ public static class RecompExtensions
         services.AddSingleton<IRecompEnvironment, RecompEnvironment>();
         services.AddSingleton<IRecompProcessRunner, RecompProcessRunner>();
         services.AddSingleton<IRecompSetupDownloader, RecompSetupDownloader>();
+        services.AddSingleton<IRecompRetroWfcPayloadProbe, RecompRetroWfcPayloadProbe>();
         services.AddSingleton<IRecompInstallService, RecompInstallService>();
         services.AddTransient<RecompLauncher>();
 

--- a/WheelWizard/Features/Recomp/RecompInstallService.cs
+++ b/WheelWizard/Features/Recomp/RecompInstallService.cs
@@ -192,10 +192,8 @@ public sealed class RecompInstallService : IRecompInstallService
         state is { IsRetroWfcPayloadSkipped: true } && await payloadProbe.IsReachableAsync(cancellationToken);
 
     /// <summary>
-    /// Decides which payload option the next setup operation receives. An installation that already embeds
-    /// a payload always asks the host to download: the host falls back to its own verified copy when the
-    /// service is down. A skipped installation upgrades when the service is back and otherwise stays as
-    /// it is. Only a fresh Retro Rewind build has nothing to fall back to, which is when the user decides.
+    /// Decides which payload option the next setup operation receives. The rules live in
+    /// <see cref="RecompRetroWfcPayloadPolicy"/>; this only supplies the probe and the user's answer.
     /// </summary>
     private async Task<OperationResult<RecompRetroWfcPayloadMode>> ResolveRetroWfcPayloadModeAsync(
         RecompInstallState? state,
@@ -203,24 +201,24 @@ public sealed class RecompInstallService : IRecompInstallService
         CancellationToken cancellationToken
     )
     {
-        if (string.IsNullOrWhiteSpace(environment.RetroRewindFolderPath))
-            return Ok(RecompRetroWfcPayloadMode.Download);
+        var hasRetroRewindSource = !string.IsNullOrWhiteSpace(environment.RetroRewindFolderPath);
+        var serviceReachable =
+            !RecompRetroWfcPayloadPolicy.NeedsServiceProbe(state, hasRetroRewindSource)
+            || await payloadProbe.IsReachableAsync(cancellationToken);
 
-        var installedMode = state?.RetroWfcPayloadMode;
-        if (string.Equals(installedMode, "downloaded", StringComparison.OrdinalIgnoreCase))
-            return Ok(RecompRetroWfcPayloadMode.Download);
+        switch (RecompRetroWfcPayloadPolicy.Decide(state, hasRetroRewindSource, serviceReachable))
+        {
+            case RecompRetroWfcPayloadDecision.Download:
+                return Ok(RecompRetroWfcPayloadMode.Download);
+            case RecompRetroWfcPayloadDecision.Skip:
+                return Ok(RecompRetroWfcPayloadMode.Skip);
+            default:
+                if (confirmOfflineInstall is null || !await confirmOfflineInstall())
+                    return Fail(RetroWfcUnavailableMessage);
 
-        if (await payloadProbe.IsReachableAsync(cancellationToken))
-            return Ok(RecompRetroWfcPayloadMode.Download);
-
-        if (state is { IsRetroWfcPayloadSkipped: true })
-            return Ok(RecompRetroWfcPayloadMode.Skip);
-
-        if (confirmOfflineInstall is null || !await confirmOfflineInstall())
-            return Fail(RetroWfcUnavailableMessage);
-
-        logger.LogInformation("The Retro-WFC payload service is unreachable; installing WiiCompiled without online play");
-        return Ok(RecompRetroWfcPayloadMode.Skip);
+                logger.LogInformation("The Retro-WFC payload service is unreachable; installing WiiCompiled without online play");
+                return Ok(RecompRetroWfcPayloadMode.Skip);
+        }
     }
 
     /// <summary>

--- a/WheelWizard/Features/Recomp/RecompInstallService.cs
+++ b/WheelWizard/Features/Recomp/RecompInstallService.cs
@@ -39,7 +39,17 @@ public interface IRecompInstallService : IDisposable
     /// Installs a missing/newer setup release, or asks the installed setup host what needs doing and
     /// repairs only that. An asset-only Retro Rewind change reports <c>current</c> and does no work.
     /// </summary>
-    Task<OperationResult> InstallAsync(IProgress<RecompInstallProgress>? progress = null, CancellationToken cancellationToken = default);
+    /// <param name="confirmOfflineInstall">
+    /// Consulted only when a fresh Retro Rewind build is needed and the Retro-WFC payload service is
+    /// unreachable. Returning true builds without online play; false or <see langword="null"/> fails the
+    /// install with an explanation instead. An installation that already embeds a payload never asks: the
+    /// setup host falls back to its own verified copy.
+    /// </param>
+    Task<OperationResult> InstallAsync(
+        IProgress<RecompInstallProgress>? progress = null,
+        Func<Task<bool>>? confirmOfflineInstall = null,
+        CancellationToken cancellationToken = default
+    );
 
     /// <summary>
     /// Verifies product health immediately before launch and repairs only what the check demands.
@@ -86,11 +96,15 @@ public sealed class RecompInstallService : IRecompInstallService
     // installation is probed by pattern rather than by recomputing the backend's own path.
     private const string OperationLockSearchPattern = ".mkwc-operation-*.lock";
 
+    private const string RetroWfcUnavailableMessage =
+        "The Retro WFC servers are not responding, so WiiCompiled cannot set up online play right now. Try again later, or install without online play.";
+
     private static readonly JsonSerializerOptions InstallStateJsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     private readonly IRecompEnvironment environment;
     private readonly IRecompProcessRunner processRunner;
     private readonly IRecompSetupDownloader downloader;
+    private readonly IRecompRetroWfcPayloadProbe payloadProbe;
     private readonly IGitHubSingletonService gitHubService;
     private readonly IFileSystem fileSystem;
     private readonly ILogger<RecompInstallService> logger;
@@ -105,6 +119,7 @@ public sealed class RecompInstallService : IRecompInstallService
         IRecompEnvironment environment,
         IRecompProcessRunner processRunner,
         IRecompSetupDownloader downloader,
+        IRecompRetroWfcPayloadProbe payloadProbe,
         IGitHubSingletonService gitHubService,
         IFileSystem fileSystem,
         ILogger<RecompInstallService> logger
@@ -113,6 +128,7 @@ public sealed class RecompInstallService : IRecompInstallService
         this.environment = environment;
         this.processRunner = processRunner;
         this.downloader = downloader;
+        this.payloadProbe = payloadProbe;
         this.gitHubService = gitHubService;
         this.fileSystem = fileSystem;
         this.logger = logger;
@@ -149,13 +165,62 @@ public sealed class RecompInstallService : IRecompInstallService
         if (installationBusy)
             logger.LogInformation("The WiiCompiled product check could not run because the installation is busy");
 
-        return RecompStatusResolver.Resolve(
+        var status = RecompStatusResolver.Resolve(
             IsGameFileConfigured(),
             hasInstalledHost ? installedVersion : null,
             latestRelease?.TagName,
             products?.IsSuccess == true ? products.Value : null,
             installationBusy
         );
+
+        // A build that skipped the payload is healthy as far as the host is concerned, but it cannot
+        // play online. Once the payload service is back, that is an update worth offering.
+        if (
+            status is (WheelWizardStatus.Ready or WheelWizardStatus.NoServerButInstalled)
+            && await RetroWfcUpgradeAvailableAsync(state, cancellationToken)
+        )
+            return WheelWizardStatus.OutOfDate;
+
+        return status;
+    }
+
+    /// <summary>
+    /// Whether the installed Retro Rewind product was built without a Retro-WFC payload while the payload
+    /// service is reachable again. Only a skipped installation ever probes, so a normal one costs nothing.
+    /// </summary>
+    private async Task<bool> RetroWfcUpgradeAvailableAsync(RecompInstallState? state, CancellationToken cancellationToken) =>
+        state is { IsRetroWfcPayloadSkipped: true } && await payloadProbe.IsReachableAsync(cancellationToken);
+
+    /// <summary>
+    /// Decides which payload option the next setup operation receives. An installation that already embeds
+    /// a payload always asks the host to download: the host falls back to its own verified copy when the
+    /// service is down. A skipped installation upgrades when the service is back and otherwise stays as
+    /// it is. Only a fresh Retro Rewind build has nothing to fall back to, which is when the user decides.
+    /// </summary>
+    private async Task<OperationResult<RecompRetroWfcPayloadMode>> ResolveRetroWfcPayloadModeAsync(
+        RecompInstallState? state,
+        Func<Task<bool>>? confirmOfflineInstall,
+        CancellationToken cancellationToken
+    )
+    {
+        if (string.IsNullOrWhiteSpace(environment.RetroRewindFolderPath))
+            return Ok(RecompRetroWfcPayloadMode.Download);
+
+        var installedMode = state?.RetroWfcPayloadMode;
+        if (string.Equals(installedMode, "downloaded", StringComparison.OrdinalIgnoreCase))
+            return Ok(RecompRetroWfcPayloadMode.Download);
+
+        if (await payloadProbe.IsReachableAsync(cancellationToken))
+            return Ok(RecompRetroWfcPayloadMode.Download);
+
+        if (state is { IsRetroWfcPayloadSkipped: true })
+            return Ok(RecompRetroWfcPayloadMode.Skip);
+
+        if (confirmOfflineInstall is null || !await confirmOfflineInstall())
+            return Fail(RetroWfcUnavailableMessage);
+
+        logger.LogInformation("The Retro-WFC payload service is unreachable; installing WiiCompiled without online play");
+        return Ok(RecompRetroWfcPayloadMode.Skip);
     }
 
     /// <summary>
@@ -265,6 +330,7 @@ public sealed class RecompInstallService : IRecompInstallService
 
     public async Task<OperationResult> InstallAsync(
         IProgress<RecompInstallProgress>? progress = null,
+        Func<Task<bool>>? confirmOfflineInstall = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -273,7 +339,7 @@ public sealed class RecompInstallService : IRecompInstallService
 
         try
         {
-            return await InstallCoreAsync(progress, cancellationToken);
+            return await InstallCoreAsync(progress, confirmOfflineInstall, cancellationToken);
         }
         finally
         {
@@ -281,7 +347,11 @@ public sealed class RecompInstallService : IRecompInstallService
         }
     }
 
-    private async Task<OperationResult> InstallCoreAsync(IProgress<RecompInstallProgress>? progress, CancellationToken cancellationToken)
+    private async Task<OperationResult> InstallCoreAsync(
+        IProgress<RecompInstallProgress>? progress,
+        Func<Task<bool>>? confirmOfflineInstall,
+        CancellationToken cancellationToken
+    )
     {
         // No platform guard here on purpose: AddRecomp() is the single gate, so this service only ever
         // exists on Windows in the first place.
@@ -289,28 +359,40 @@ public sealed class RecompInstallService : IRecompInstallService
             return Fail(t("message_warning.not_find_game.extra"));
 
         Report(progress, t("progress.recomp_checking_release"), 0);
-        var installedVersion = ReadInstalledVersion();
+        var state = ReadInstalledState();
+        var installedVersion = string.IsNullOrWhiteSpace(state?.SetupVersion) ? null : state.SetupVersion;
         var hasInstalledHost = fileSystem.File.Exists(environment.InstalledSetupFilePath);
         var release = await TryGetLatestReleaseAsync(cancellationToken);
+
+        // Decided up front, before any download or build, so the user is asked while nothing has started
+        // yet rather than after a multi-minute build has already failed on the payload.
+        var payloadModeResult = await ResolveRetroWfcPayloadModeAsync(state, confirmOfflineInstall, cancellationToken);
+        if (payloadModeResult.IsFailure)
+            return payloadModeResult.Error;
+        var payloadMode = payloadModeResult.Value;
+
+        // A skipped installation that can download again is an update in its own right: the host only
+        // rebuilds when told the payload choice changed, and --check-products alone never says so.
+        var forceRetroRebuild = state is { IsRetroWfcPayloadSkipped: true } && payloadMode == RecompRetroWfcPayloadMode.Download;
 
         // A repair is deliberately independent of GitHub: once a setup host has been installed,
         // it owns the installed toolkit/workspace and can bring changed compile inputs current offline.
         if (release is null)
         {
             if (hasInstalledHost && await InstalledHostCanRepairAsync(installedVersion, cancellationToken))
-                return await RepairWhatTheCheckDemandsAsync(progress, cancellationToken);
+                return await RepairWhatTheCheckDemandsAsync(progress, payloadMode, forceRetroRebuild, cancellationToken);
 
             return Fail("Could not verify a current WiiCompiled setup release or installed repair host.");
         }
 
         if (hasInstalledHost && await InstalledHostCanRepairAsync(release.TagName, cancellationToken))
-            return await RepairWhatTheCheckDemandsAsync(progress, cancellationToken);
+            return await RepairWhatTheCheckDemandsAsync(progress, payloadMode, forceRetroRebuild, cancellationToken);
 
         var setupResult = await EnsureSetupDownloadedAsync(release, progress, cancellationToken);
         if (setupResult.IsFailure)
             return setupResult.Error;
 
-        return await RunSilentInstallAsync(setupResult.Value, progress, cancellationToken);
+        return await RunSilentInstallAsync(setupResult.Value, payloadMode, progress, cancellationToken);
     }
 
     public async Task<OperationResult> ReconcileForLaunchAsync(
@@ -346,7 +428,19 @@ public sealed class RecompInstallService : IRecompInstallService
         if (!await SetupMatchesVersionAsync(environment.InstalledSetupFilePath, state.SetupVersion, cancellationToken))
             return Fail("The installed WiiCompiled host does not match its current install state.");
 
-        var repairResult = await RepairWhatTheCheckDemandsCoreAsync(progress, reportCompletion: false, cancellationToken);
+        // A launch never asks about offline play and never forces the payload upgrade: the user pressed
+        // Play, not Update. A repair the check demands anyway still gains the payload when it is reachable.
+        var payloadModeResult = await ResolveRetroWfcPayloadModeAsync(state, confirmOfflineInstall: null, cancellationToken);
+        if (payloadModeResult.IsFailure)
+            return payloadModeResult.Error;
+
+        var repairResult = await RepairWhatTheCheckDemandsCoreAsync(
+            progress,
+            payloadModeResult.Value,
+            forceRetroRebuild: false,
+            reportCompletion: false,
+            cancellationToken
+        );
         if (repairResult.IsFailure)
             return repairResult;
 
@@ -582,6 +676,7 @@ public sealed class RecompInstallService : IRecompInstallService
 
     private async Task<OperationResult> RunSilentInstallAsync(
         string setupFilePath,
+        RecompRetroWfcPayloadMode payloadMode,
         IProgress<RecompInstallProgress>? progress,
         CancellationToken cancellationToken
     )
@@ -592,6 +687,7 @@ public sealed class RecompInstallService : IRecompInstallService
             InstallFolderPath = environment.InstallFolderPath,
             RetroRewindFolderPath = environment.RetroRewindFolderPath,
             Portable = environment.IsPortableInstall,
+            RetroWfcPayloadMode = payloadMode,
         };
 
         var arguments = RecompSetupCommandBuilder.BuildSilentInstallArguments(request);
@@ -621,11 +717,20 @@ public sealed class RecompInstallService : IRecompInstallService
     /// </summary>
     private async Task<OperationResult> RepairWhatTheCheckDemandsAsync(
         IProgress<RecompInstallProgress>? progress,
+        RecompRetroWfcPayloadMode payloadMode,
+        bool forceRetroRebuild,
         CancellationToken cancellationToken
-    ) => await RepairWhatTheCheckDemandsCoreAsync(progress, reportCompletion: true, cancellationToken);
+    ) => await RepairWhatTheCheckDemandsCoreAsync(progress, payloadMode, forceRetroRebuild, reportCompletion: true, cancellationToken);
 
+    /// <param name="forceRetroRebuild">
+    /// Runs the repair even when the check reports every product current. The host decides for itself
+    /// what that repair rebuilds; this exists so a payload choice that changed, which the check does
+    /// not see, still reaches it.
+    /// </param>
     private async Task<OperationResult> RepairWhatTheCheckDemandsCoreAsync(
         IProgress<RecompInstallProgress>? progress,
+        RecompRetroWfcPayloadMode payloadMode,
+        bool forceRetroRebuild,
         bool reportCompletion,
         CancellationToken cancellationToken
     )
@@ -634,7 +739,7 @@ public sealed class RecompInstallService : IRecompInstallService
         if (checkResult.IsFailure)
             return checkResult.Error;
 
-        if (!NeedsRepair(checkResult.Value))
+        if (!NeedsRepair(checkResult.Value) && !forceRetroRebuild)
         {
             if (reportCompletion)
                 Report(progress, t("progress.recomp_finished"), 100);
@@ -642,13 +747,14 @@ public sealed class RecompInstallService : IRecompInstallService
         }
 
         logger.LogInformation(
-            "Repairing WiiCompiled products (base: {BaseStatus}, retro: {RetroStatus}, compile required: {CompileRequired})",
+            "Repairing WiiCompiled products (base: {BaseStatus}, retro: {RetroStatus}, compile required: {CompileRequired}, payload: {PayloadMode})",
             checkResult.Value.Base.State,
             checkResult.Value.RetroRewind.State,
-            checkResult.Value.Base.RequiresCompile || checkResult.Value.RetroRewind.RequiresCompile
+            checkResult.Value.Base.RequiresCompile || checkResult.Value.RetroRewind.RequiresCompile,
+            payloadMode
         );
 
-        var repairResult = await RunTargetedRepairAsync(progress, cancellationToken);
+        var repairResult = await RunTargetedRepairAsync(progress, payloadMode, cancellationToken);
         if (repairResult.IsFailure)
             return repairResult;
 
@@ -667,6 +773,7 @@ public sealed class RecompInstallService : IRecompInstallService
 
     private async Task<OperationResult> RunTargetedRepairAsync(
         IProgress<RecompInstallProgress>? progress,
+        RecompRetroWfcPayloadMode payloadMode,
         CancellationToken cancellationToken
     )
     {
@@ -676,7 +783,11 @@ public sealed class RecompInstallService : IRecompInstallService
         if (string.IsNullOrWhiteSpace(retroRewindFolderPath))
             return Fail("Retro Rewind must be installed before WiiCompiled can repair or launch.");
 
-        var arguments = RecompSetupCommandBuilder.BuildRepairProductsArguments(environment.InstallFolderPath, retroRewindFolderPath);
+        var arguments = RecompSetupCommandBuilder.BuildRepairProductsArguments(
+            environment.InstallFolderPath,
+            retroRewindFolderPath,
+            payloadMode
+        );
 
         Report(progress, t("progress.recomp_running_setup"), SetupPercentFloor);
         var resultHolder = new EventHolder<RecompSetupResultEvent>();
@@ -782,12 +893,6 @@ public sealed class RecompInstallService : IRecompInstallService
         }
 
         return RecompReleaseResolver.FindLatest(releasesResult.Value);
-    }
-
-    private string? ReadInstalledVersion()
-    {
-        var state = ReadInstalledState();
-        return string.IsNullOrWhiteSpace(state?.SetupVersion) ? null : state.SetupVersion;
     }
 
     private RecompInstallState? ReadInstalledState()

--- a/WheelWizard/Features/Recomp/RecompLauncher.cs
+++ b/WheelWizard/Features/Recomp/RecompLauncher.cs
@@ -249,6 +249,7 @@ public class RecompLauncher(
             // handed an uncancellable token. Whatever the backend reports is the truth.
             return await installService.InstallAsync(
                 progress,
+                ConfirmOfflineInstallAsync,
                 retroRewindCommitted ? CancellationToken.None : cancellationTokenSource.Token
             );
         }
@@ -261,6 +262,18 @@ public class RecompLauncher(
             progressWindow.Close();
         }
     }
+
+    /// <summary>
+    /// Asked by the install service only when a Retro Rewind build is needed and the Retro-WFC payload
+    /// service is down. Offline-only is a real choice, not a silent downgrade: the game plays, online
+    /// does not, and the next update after the service returns rebuilds with online play automatically.
+    /// </summary>
+    private static Task<bool> ConfirmOfflineInstallAsync() =>
+        new YesNoWindow()
+            .SetButtonText(t("action.recomp_install_offline"), t("action.cancel"))
+            .SetMainText(t("question.recomp_retro_wfc_unavailable.title"))
+            .SetExtraText(t("question.recomp_retro_wfc_unavailable.extra"))
+            .AwaitAnswer();
 
     private async Task<OperationResult<bool>> EnsureRetroRewindCurrentAsync(
         ProgressWindow progressWindow,

--- a/WheelWizard/Features/Recomp/RecompRetroWfcPayloadPolicy.cs
+++ b/WheelWizard/Features/Recomp/RecompRetroWfcPayloadPolicy.cs
@@ -1,0 +1,61 @@
+using WheelWizard.Recomp.Domain;
+
+namespace WheelWizard.Recomp;
+
+/// <summary>
+/// What the install service should do about the Retro-WFC payload for the next setup operation.
+/// </summary>
+public enum RecompRetroWfcPayloadDecision
+{
+    /// <summary>Pass <c>--download-retro-wfc-payload</c>.</summary>
+    Download,
+
+    /// <summary>Pass <c>--skip-retro-wfc-payload</c> without asking: the installation is already offline-only.</summary>
+    Skip,
+
+    /// <summary>A fresh Retro Rewind build cannot get its payload; only the user can choose offline-only.</summary>
+    AskUser,
+}
+
+/// <summary>
+/// The pure decision behind the payload option, kept free of I/O so the cases can be tested directly.
+/// An installation that already embeds a payload always asks the host to download, because the host
+/// falls back to its own verified copy when the service is down. A skipped installation upgrades when
+/// the service is back and otherwise stays as it is. Only a Retro Rewind build with nothing to fall
+/// back to is the user's call.
+/// </summary>
+public static class RecompRetroWfcPayloadPolicy
+{
+    /// <summary>
+    /// Whether the decision depends on the payload service at all. When it does not, no probe should run:
+    /// a normal installation must never wait on a dead endpoint just to be told what it already knows.
+    /// </summary>
+    public static bool NeedsServiceProbe(RecompInstallState? state, bool hasRetroRewindSource) =>
+        hasRetroRewindSource && !HasVerifiedPayload(state);
+
+    /// <summary>
+    /// Decides the payload option. <paramref name="serviceReachable"/> is only consulted when
+    /// <see cref="NeedsServiceProbe"/> says so; pass any value otherwise.
+    /// </summary>
+    public static RecompRetroWfcPayloadDecision Decide(RecompInstallState? state, bool hasRetroRewindSource, bool serviceReachable)
+    {
+        if (!NeedsServiceProbe(state, hasRetroRewindSource) || serviceReachable)
+            return RecompRetroWfcPayloadDecision.Download;
+
+        return state is { IsRetroWfcPayloadSkipped: true } ? RecompRetroWfcPayloadDecision.Skip : RecompRetroWfcPayloadDecision.AskUser;
+    }
+
+    /// <summary>
+    /// Whether the installed Retro Rewind product carries a payload the host can fall back to. A state
+    /// that predates the mode field but reports Retro Rewind installed counts: every host so far has
+    /// only ever built Retro Rewind with a downloaded payload, so absent means downloaded, never skipped.
+    /// </summary>
+    private static bool HasVerifiedPayload(RecompInstallState? state)
+    {
+        if (state is null)
+            return false;
+        if (string.Equals(state.RetroWfcPayloadMode, "downloaded", StringComparison.OrdinalIgnoreCase))
+            return true;
+        return string.IsNullOrWhiteSpace(state.RetroWfcPayloadMode) && state.RetroRewindInstalled;
+    }
+}

--- a/WheelWizard/Features/Recomp/RecompRetroWfcPayloadProbe.cs
+++ b/WheelWizard/Features/Recomp/RecompRetroWfcPayloadProbe.cs
@@ -1,0 +1,86 @@
+using Microsoft.Extensions.Logging;
+
+namespace WheelWizard.Recomp;
+
+/// <summary>
+/// Answers whether the shared Retro-WFC payload can currently be downloaded. The setup host is the only
+/// thing that ever downloads and verifies the payload; this probe exists so WheelWizard can decide, before
+/// starting a long install, whether to ask the user for an offline-only build instead of failing later.
+/// </summary>
+public interface IRecompRetroWfcPayloadProbe
+{
+    /// <summary>
+    /// True when the payload endpoint answered with a success status. Never throws: any failure, including
+    /// a timeout, simply reads as unreachable.
+    /// </summary>
+    Task<bool> IsReachableAsync(CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc />
+public sealed class RecompRetroWfcPayloadProbe(IHttpClientFactory httpClientFactory, ILogger<RecompRetroWfcPayloadProbe> logger)
+    : IRecompRetroWfcPayloadProbe
+{
+    /// <summary>
+    /// The fixed payload endpoint the setup host downloads from. It must stay identical to the value pinned
+    /// in the recomp's <c>RetroWfcPayload.CurrentRetroWfcPayloadUri</c>, since probing anything else says
+    /// nothing about whether the host's own download will succeed.
+    /// </summary>
+    public const string PayloadUri = "http://nas.play.rwfc.net/payload?g=RMCPD00";
+
+    // A dead endpoint times out rather than refusing, so a short cap is what keeps the home page and the
+    // install flow from stalling on every status refresh while the service is down.
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(6);
+
+    // A status refresh and the install that follows it should not each pay for their own probe.
+    private static readonly TimeSpan ResultLifetime = TimeSpan.FromSeconds(60);
+
+    private readonly object _cacheLock = new();
+    private DateTimeOffset _cachedAtUtc = DateTimeOffset.MinValue;
+    private bool _cachedResult;
+
+    public async Task<bool> IsReachableAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_cacheLock)
+        {
+            if (DateTimeOffset.UtcNow - _cachedAtUtc < ResultLifetime)
+                return _cachedResult;
+        }
+
+        var reachable = await ProbeAsync(cancellationToken);
+
+        lock (_cacheLock)
+        {
+            _cachedResult = reachable;
+            _cachedAtUtc = DateTimeOffset.UtcNow;
+        }
+
+        return reachable;
+    }
+
+    private async Task<bool> ProbeAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutSource.CancelAfter(ProbeTimeout);
+
+            // Headers only: the payload is a multi-megabyte binary and its bytes are the host's business.
+            var client = httpClientFactory.CreateClient(RecompSetupDownloader.HttpClientName);
+            using var response = await client.GetAsync(PayloadUri, HttpCompletionOption.ResponseHeadersRead, timeoutSource.Token);
+            if (response.IsSuccessStatusCode)
+                return true;
+
+            logger.LogWarning("The Retro-WFC payload endpoint answered {StatusCode}", (int)response.StatusCode);
+            return false;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning("The Retro-WFC payload endpoint is unreachable: {Message}", exception.Message);
+            return false;
+        }
+    }
+}

--- a/WheelWizard/Features/Recomp/RecompRetroWfcPayloadProbe.cs
+++ b/WheelWizard/Features/Recomp/RecompRetroWfcPayloadProbe.cs
@@ -23,7 +23,10 @@ public sealed class RecompRetroWfcPayloadProbe(IHttpClientFactory httpClientFact
     /// <summary>
     /// The fixed payload endpoint the setup host downloads from. It must stay identical to the value pinned
     /// in the recomp's <c>RetroWfcPayload.CurrentRetroWfcPayloadUri</c>, since probing anything else says
-    /// nothing about whether the host's own download will succeed.
+    /// nothing about whether the host's own download will succeed. Plain HTTP is what the service offers
+    /// and what the host pins; that is safe here because this probe decides nothing about trust. The host
+    /// verifies the payload's RSA signature itself, so a forged answer can at worst make the host attempt
+    /// a download that its own verification then rejects.
     /// </summary>
     public const string PayloadUri = "http://nas.play.rwfc.net/payload?g=RMCPD00";
 

--- a/WheelWizard/Features/Recomp/RecompSetupCommandBuilder.cs
+++ b/WheelWizard/Features/Recomp/RecompSetupCommandBuilder.cs
@@ -45,7 +45,7 @@ public static class RecompSetupCommandBuilder
         {
             arguments.Add("--retro-dir");
             arguments.Add(Quote(request.RetroRewindFolderPath));
-            arguments.Add(RetroWfcPayloadArgument);
+            arguments.Add(RetroWfcPayloadArgument(request.RetroWfcPayloadMode));
         }
 
         return string.Join(' ', arguments);
@@ -56,7 +56,11 @@ public static class RecompSetupCommandBuilder
     /// toolkit the installation already owns instead of an embedded payload. Every repair receives the
     /// Retro Rewind source and exactly one Retro-WFC payload option, as the contract requires.
     /// </summary>
-    public static string BuildRepairProductsArguments(string installFolderPath, string retroRewindFolderPath)
+    public static string BuildRepairProductsArguments(
+        string installFolderPath,
+        string retroRewindFolderPath,
+        RecompRetroWfcPayloadMode retroWfcPayloadMode = RecompRetroWfcPayloadMode.Download
+    )
     {
         if (string.IsNullOrWhiteSpace(installFolderPath))
             throw new ArgumentException("An install directory is required.", nameof(installFolderPath));
@@ -70,7 +74,7 @@ public static class RecompSetupCommandBuilder
             Quote(installFolderPath),
             "--retro-dir",
             Quote(retroRewindFolderPath),
-            RetroWfcPayloadArgument,
+            RetroWfcPayloadArgument(retroWfcPayloadMode),
             "--progress-json"
         );
     }
@@ -106,9 +110,10 @@ public static class RecompSetupCommandBuilder
     /// </summary>
     public static string BuildVersionArguments() => "--version";
 
-    // The contract requires exactly one payload option (--download-retro-wfc-payload or
-    // --skip-retro-wfc-payload) whenever --retro-dir is passed; WheelWizard always downloads.
-    private const string RetroWfcPayloadArgument = "--download-retro-wfc-payload";
+    // The contract requires exactly one payload option whenever --retro-dir is passed. WheelWizard
+    // downloads unless the payload service is unreachable and the user chose an offline-only build.
+    private static string RetroWfcPayloadArgument(RecompRetroWfcPayloadMode mode) =>
+        mode == RecompRetroWfcPayloadMode.Skip ? "--skip-retro-wfc-payload" : "--download-retro-wfc-payload";
 
     // The recomp is Windows only, so quoting is always Windows quoting (never the POSIX form EnvHelper would pick).
     private static string Quote(string path)

--- a/WheelWizard/Resources/Languages/en.yml
+++ b/WheelWizard/Resources/Languages/en.yml
@@ -141,6 +141,7 @@ en:
     view_room: "View Room"
     recomp_nand_copy: "Make a copy"
     recomp_nand_share: "Use directly"
+    recomp_install_offline: "Install offline-only"
     link:
       discord: "Talk to us!"
       github: "Source code"
@@ -270,6 +271,9 @@ en:
     recomp_use_dolphin_nand:
       title: "Use your Dolphin save data?"
       extra: "WiiCompiled can play with the saves, Miis and friend codes you already use in Dolphin. If not, it starts fresh with its own Wii data."
+    recomp_retro_wfc_unavailable:
+      title: "Retro WFC is unreachable"
+      extra: "WiiCompiled needs the Retro WFC servers to set up online play, and they are not responding right now. You can install without online play now; WiiCompiled will add it automatically the next time you update once the servers are back."
     recomp_nand_mode:
       title: "Copy your Dolphin data, or use it directly?"
       extra: "Dolphin recommends against other programs using its Wii data (NAND) directly, since two programs writing to it at once can corrupt it. A copy keeps WiiCompiled completely separate, but progress made in one will not appear in the other."


### PR DESCRIPTION
add support to skip the payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline-only WiiCompiled installation when the Retro-WFC payload service is unavailable.
  * Added a confirmation prompt before starting an offline installation.
  * Install and repair operations can now download or skip the Retro-WFC payload.
  * Installation status identifies when a skipped payload is available again.

* **Bug Fixes**
  * Prevented conflicting payload download and skip options from being passed together.

* **Localization**
  * Added English text for offline installation prompts and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->