### PR TITLE
fix(flatpak): Add version `2.5.3` to metainfo `.xml`

### DIFF
--- a/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
+++ b/Flatpak/io.github.TeamWheelWizard.WheelWizard.metainfo.xml
@@ -55,6 +55,7 @@
   </provides>
 
   <releases>
+    <release version="2.5.3" date="2026-09-03"/>
     <release version="2.5.2" date="2026-08-27"/>
     <release version="2.5.1" date="2026-08-24"/>
     <release version="2.5.0" date="2026-08-23"/>


### PR DESCRIPTION
The release was missing this entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release metadata for version 2.5.3, including its release date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->