### PR TITLE
l10n: French translation update & improvements

### DIFF
--- a/WheelWizard/Resources/Languages/fr.yml
+++ b/WheelWizard/Resources/Languages/fr.yml
@@ -502,7 +502,7 @@ fr:
       message: "Ce mod est incompatible avec d'autres. Lancer en le gardant activé peut provoquer des crashs ou des comportements inattendus. Pensez à le convertir en patchs en faisant un clic droit sur le mod."
       title: "MOD INCOMPATIBLE"
   warning:
-    brsar_external_count: "{$1} Les entrées de fichier BRSAR sont des références externes et ne peuvent pas être exportées."
+    brsar_external_count: "{$1} entrées de fichier BRSAR sont des références externes et ne peuvent pas être exportées."
     brsar_file_id_external: "Le fileID BRSAR {$1} est une référence externe de fichier et ne peut pas être exporté."
     brsar_file_id_unsupported_magic: "Le fileID BRSAR {$1} a changé, mais il correspond à {$2} et Pulsar ne prend en charge que les remplacements \"en loose\" de fichiers RBNK/RSEQ/RWSD."
     brsar_file_id_unresolved: "Le fileID BRSAR {$1} ne correspond à aucun fichier audio intégré pris en charge."

--- a/WheelWizard/Resources/Languages/fr.yml
+++ b/WheelWizard/Resources/Languages/fr.yml
@@ -113,7 +113,7 @@ fr:
     install: "Installer"
     update: "Mettre à Jour"
     import: "Importer"
-    clone: "Cloner"
+    clone: "Copier"
     convert_to_patches: "Convertir en Patchs"
     enable_all: "Tout Activer"
     disable_all: "Tout Désactiver"

--- a/WheelWizard/Resources/Languages/fr.yml
+++ b/WheelWizard/Resources/Languages/fr.yml
@@ -558,8 +558,8 @@ fr:
   helper_text:
     topbar:
       location_warning: "Les paramètres sont désactivés, finissez d'abord les paramètres de localisation"
-    enable_recomp: "Utilise Wiicompiled comme launcher. Désactivez pour utiliser Dolphin et Retro Rewind à la place. Windows uniquement."
-    recomp_use_dolphin_data: "Utilise le dossier Wii existant de Dolphin afin que WiiCompiled puisse partager les sauvegardes, Miis, et paramètres Wii. Les changements prennent effet au prochain lancement de Wiicompiled."
+    enable_recomp: "Utilise WiiCompiled comme lanceur. Désactivez pour utiliser Dolphin et Retro Rewind à la place. Windows uniquement."
+    recomp_use_dolphin_data: "Utilise le dossier Wii existant de Dolphin afin que WiiCompiled puisse partager les sauvegardes, Miis, et paramètres Wii. Les changements prennent effet au prochain lancement de WiiCompiled."
     recomp_graphics_api: "Seuls DirectX 12 et Vulkan font tourner WiiCompiled fiablement, donc rien d'autre n'est proposé."
     recomp_dolphin_data_not_found: "Définissez un chemin vers le dossier utilisateur Dolphin dans les paramètres de localisation. Il doit contenir un dossier Wii."
     recomp_prevent_stutters: "Lors de la compilation d'un shader, les objets qui ont en besoin sont ignorés pendant quelques frames au lieu de bloquer le jeu jusqu'a ce que la compilation soit terminée, provoquant un léger effet de \"pop-in\" au lieu d'un ralentissement"

--- a/WheelWizard/Resources/Languages/fr.yml
+++ b/WheelWizard/Resources/Languages/fr.yml
@@ -4,10 +4,10 @@ fr:
     settings: "Paramètres"
     mods: "My Stuff"
     patches: "Patchs"
-    my_profiles: "Mes Permis"
+    my_profiles: "Mes Profils"
     rooms: "Salles"
     friends: "Amis"
-    leaderboard: "Leaderboard"
+    leaderboard: "Classements"
     room_details: "Détails de la salle"
     my_miis: "Mes Miis"
   attribute:
@@ -94,7 +94,7 @@ fr:
     installing: "Installation..."
     updating: "Mise à jour..."
     config_not_finished: "Configuration non terminée"
-    no_server: "Aucun Seveur"
+    no_server: "Aucun serveur"
     unknown: "Inconnu"
     error: "Erreur"
     warning: "Avertissement"
@@ -107,11 +107,13 @@ fr:
     installed: "Installé"
   action:
     play: "Jouer"
+    open: "Ouvrir"
     play_offline: "Jouer hors ligne"
     play_anyway: "Jouer quand même"
     install: "Installer"
     update: "Mettre à Jour"
     import: "Importer"
+    clone: "Cloner"
     convert_to_patches: "Convertir en Patchs"
     enable_all: "Tout Activer"
     disable_all: "Tout Désactiver"
@@ -131,6 +133,7 @@ fr:
     revert: "Annuler"
     maybe_later: "Peut-être plus tard"
     browse: "Chercher"
+    change: "Changer"
     view_mod: "Détails du Mod"
     save_external_mii: "Ajouter un Mii dans \"Mes Miis\""
     view_mii: "Voir le Mii"
@@ -171,11 +174,11 @@ fr:
   popup_title:
     mod_details: "Détails du mod"
     mod_browser: "Navigateur de mods"
-    mii_selector: "Sélection de Mii"
+    mii_selector: "Sélecteur de Mii"
     mii_editor: "Éditeur de Mii"
     mii_carousel: "Vue d'ensemble des Miis"
   text:
-    made_by_string: |
+    made_by_string: |-
       Fait par: {$1}
       et {$2}
     thanks_translators: "Merci à tous les traducteurs:"
@@ -197,7 +200,7 @@ fr:
     rooms_online:
       0: "Il n'y a actuellement aucune salle active"
       1: "Il y a actuellement 1 salle active"
-      n: "Il y a actuellement {$1} salles active"
+      n: "Il y a actuellement {$1} salles actives"
     friends_online:
       0: "Il n'y a actuellement aucun ami en ligne"
       1: "Il y a actuellement 1 ami en ligne"
@@ -206,7 +209,7 @@ fr:
       Attention, cette page ne permet pas de rejoindre une salle directement.
       Pour rejoindre une salle spécifique, vous devez soit la rejoindre via un ami, soit espérer la rejoindre via les serveurs en ligne.
     friends_page_disclaimer: "Pour ajouter des amis rendez vous en jeu."
-    region_user_selection: "Ceci montre les régions dans lesquelles VOUS avez joué(e)"
+    region_user_selection: "Ceci montre les régions dans lesquelles VOUS avez joué"
     primary_profile: "Le profil principal est utilisé en tant que référence dans Wheel Wizard"
   empty_content:
     no_profiles: "Vous devez lancer le jeu au moins une fois pour voir vos profils apparaître ici"
@@ -214,12 +217,12 @@ fr:
     no_friends: "Vous pouvez ajouter vos amis en jeu."
     no_mods: "Les mods permettent de modifer le fonctionnement du jeu. Commencez à importer votre premier mod en cliquant sur le bouton en-dessous."
     no_mods_title: "Pas de mods trouvés"
-    no_rooms: "Soit vous n'avez pas de connexion à Internet, soit personne ne joue."
+    no_rooms: "Soit vous n'êtes pas connecté(e) à Internet, soit personne ne joue."
     no_rooms_title: "Aucune salle trouvée"
-    no_miis_title: "Aucun Mii!"
+    no_miis_title: "Aucun Mii !"
     no_miis: "Nous ne pouvons pas lire les données de Mii de votre système. Assurez-vous d'avoir lancé le jeu au moins une fois"
     no_mod_selected_title: "Aucun mod sélectionné"
-    no_mod_selected: "Sélectionner un mod dans la liste pour voir ses détails"
+    no_mod_selected: "Sélectionnez un mod dans la liste pour voir ses détails"
   time:
     days:
       1: "1 jour"
@@ -265,10 +268,10 @@ fr:
     recomp_copying_nand: "Copie des données de Dolphin"
   question:
     recomp_uninstall:
-      title: "Désinstaller WiiCompiled?"
-      extra_shared: "Cela supprime Wiicompiled. Vos sauvegardes resteront dans le dossier Wii de Dolphin, et Retro Rewind reste installé."
-      extra_private: "Cela supprime Wiicompiled, mais aussi les données de sauvegarde Wii, et Retro Rewind reste installé."
-      extra_copy: "Cela supprime Wiicompiled, mais aussi la copie de vos données Dolphin. Les données originales restent intactes, et Retro Rewind reste installé."
+      title: "Désinstaller WiiCompiled ?"
+      extra_shared: "Cela supprime WiiCompiled. Vos sauvegardes resteront dans le dossier Wii de Dolphin, et Retro Rewind reste installé."
+      extra_private: "Cela supprime WiiCompiled, mais aussi les données de sauvegarde Wii, et Retro Rewind reste installé."
+      extra_copy: "Cela supprime WiiCompiled, mais aussi la copie de vos données Dolphin. Les données originales restent intactes, et Retro Rewind reste installé."
     recomp_use_dolphin_nand:
       title: "Utiliser vos données de sauvegarde Dolphin ?"
       extra: "WiiCompiled peut démarrer avec les sauvegardes, Miis et codes ami que vous utilisiez déjà avec Dolphin. Sinon, il démarrera avec ses propres données vierges."
@@ -276,8 +279,14 @@ fr:
       title: "Impossible de communiquer avec Retro WFC"
       extra: "WiiCompiled a besoin des serveurs Retro WFC pour préparer les services en ligne, mais ils ne répondent pas. Vous pouvez installer sans les fonctionnalités en ligne; et WiiCompiled les ajoutera automatiquement lors de la prochaine mise à jour, une fois les serveurs en ligne."
     recomp_nand_mode:
-      title: "Copier les données de Dolphin, ou les utiliser directement?"
+      title: "Copier les données de Dolphin, ou les utiliser directement ?"
       extra: "Dolphin ne recommande pas l'utilisation directe de ses données Wii (NAND), car l'écriture de données par deux programmes en simultané peut provoquer leur corruption. Une copie isolera complètement WiiCompiled, mais la progression effectuée dans l'une des copies ne sera pas dans l'autre."
+    recomp_share_dolphin_data:
+      title: "Partager les données de la NAND avec Dolphin ?"
+      extra: "La copiage permet à WiiCompiled d'utiliser les mêmes sauvegardes, Miis, et paramètres Wii, mais garde sa copie isolée et est plus sûr. Le partage direct permet à Dolphin et WiiCompiled d'écrire sur la même NAND, ce qui peut la corrompre si les deux tournent en même temps. Continuez seulement si vous êtes conscient des risques."  
+    recomp_overwrite_dolphin_clone:
+      title: "Remplacer la copie isolée de Dolphin ?"
+      extra: "Cette option remplace la copie actuelle avec les données de Dolphin. Les sauvegardes, Miis, et paramètres Wii modifiés seulement sur WiiCompiled seront perdus."
     launch_clear_mods_found:
       title: "Mods trouvés"
       extra: "Vous êtes sur le point de lancer le jeu sans aucun mod. Voulez-vous supprimer le dossier My Stuff ?"
@@ -286,22 +295,19 @@ fr:
       extra: "La suppression est permanente et ne peut pas être annulée."
       title_miis: "Êtes-vous sûr de vouloir supprimer {$1} Miis ?"
     apply_scale:
-      title: "Voulez-vous appliquer la nouvelle échelle ? "
+      title: "Voulez-vous appliquer la nouvelle échelle ?"
       extra: "Cette modification va être rétablie dans {$1} sauf si vous choisissez de la garder."
     move_data:
       title: "Déplacer les données de Wheel Wizard ?"
-      extra: |
+      extra: |-
         Wheel Wizard déplacera ses fichiers vers:
-
         {$1}
-
         Cela peut prendre un moment selon la quantité de données.
     dolphin_found:
       title: "Dossier de l'émulateur Dolphin trouvé"
-      extra: |
+      extra: |-
         Si vous ne savez pas ce que cela veut dire, cliquez juste sur oui :)
-
-        Dossier de l'émulateur Dolphin trouvé. Voulez-vous utilser ce dossier ?
+        Dossier de l'émulateur Dolphin trouvé. Voulez-vous utiliser ce dossier ?
     dolphin_outdated:
       title: "Votre émulateur Dolphin est obsolète"
       extra: |
@@ -316,16 +322,16 @@ fr:
         Émulateur Dolphin trouvé. Voulez-vous l'utiliser ?
     new_version_wh_wz:
       title: "Mise à jour de Wheel Wizard disponible !"
-      extra: "La version {$1} de Wheel Wizard est disponible (Version actuelle: {$2}). Voulez-vous mettre à jour maintenant ? "
+      extra: "La version {$1} de Wheel Wizard est disponible (Version actuelle: {$2}). Voulez-vous mettre à jour maintenant ?"
     update_admin:
       title: "Mettre à jour en Administrateur"
-      extra: "Parfois, une mise à jour demande les droits d'admin. Voulez-vous les activer pour cette mise à jour ? "
+      extra: "Parfois, une mise à jour demande les droits d'admin. Voulez-vous les activer pour cette mise à jour ?"
     reinstall_rr:
-      title: "Réinstaller Retro Rewind "
+      title: "Réinstaller Retro Rewind"
       extra: "Êtes-vous sûr de vouloir réinstaller Retro Rewind ?"
     old_rksys_found:
-      title: "Ancien rksys.dat trouvé "
-      extra: "Une ancienne sauvegarde a été trouvée. Voulez-vous l'utiliser ? (Recommandé) "
+      title: "Ancien rksys.dat trouvé"
+      extra: "Une ancienne sauvegarde a été trouvée. Voulez-vous l'utiliser ? (Recommandé)"
     rr_to_old:
       extra: "Votre version de Retro Rewind est trop ancienne pour être mise à jour. Voulez-vous réinstaller Retro Rewind ?"
       title: "Votre version de Retro Rewind est trop ancienne."
@@ -349,6 +355,9 @@ fr:
       title: "Cela fermera la fenêtre actuelle et en ouvrira une nouvelle avec les nouveaux paramètres de langue."
       extra: "Voulez-vous appliquer les nouveaux paramètres de langue ?"
   message_warning:
+    recomp_operation_cancelled:
+      title: "Opération WiiCompiled annulée"
+      extra: "L'opération a été annulée avant qu'elle soit terminée. Vous pourrez la reprendre quand vous le souhaitez."
     not_find_dolphin:
       extra: "Nous n'avons pas pu trouver l'émulateur Dolphin, veuillez définir le chemin dans les paramètres"
     not_find_game:
@@ -367,30 +376,28 @@ fr:
       extra: "Le dossier de l'émulateur Dolphin n'a pas été automatiquement trouvé. Veuillez essayer de le trouver manuellement, cliquez sur \"Aide\" pour plus d'informations."
     dolphin_version_unverified:
       title: "Nous n'avons pas pu vérifier la version de votre émulateur Dolphin"
-      extra: |
+      extra: |-
         Wheel Wizard n'a pas pu lire la version de l'émulateur Dolphin que vous avez installé, donc il ne peut pas déterminer si l'émulateur a les correctifs de sécurité.
 
         Vérifiez que vous êtes sur la version {$1} ou ultérieure. Les anciennes versions ont une faille de sécurité connue qui permet aux fichiers de jeu, mods, ou tricheurs en ligne d'infecter votre PC avec des logiciels malveillants.
     dolphin_tool_selected:
-      title: "Mauvais éxecutable Dolphin sélectionné"
+      title: "Mauvais exécutable Dolphin sélectionné"
       extra: "Vous avez sélectionné DolphinTool.exe. Choisissez Dolphin.exe (l'éxecutable de l'émulateur Dolphin) à la place."
     fail_check_updates:
       title: "Échec de la vérification des mises à jour"
       extra: "Impossibilité de vérifier les mises à jour actuellement. Soit vous n'êtes pas connecté à internet soit le serveur est peut-être en maintenance"
     unable_update_wh_wz:
       extra:
-        reason_network: |
+        reason_network: |-
           Impossible de vérifier si Wheel Wizard est mis à jour.
-
           Vous avez sûrement des problèmes de connexion.
-        reason_location: |
+        reason_location: |-
           Impossible de mettre à jour Wheel Wizard. Veuillez bien vérifier que l'application se trouve dans un dossier dans lequel on peut écrire.
-
           Nous n'avons pas pu trouver le dossier actuel.
       title: "Impossible de mettre à jour Wheel Wizard."
     no_connect_server:
-      extra: "Nous n'avons pas pu se connecter au serveur. Veuillez réessayer plus tard."
-      title: "Nous n'avons pu se connecter au serveur"
+      extra: "Nous n'avons pas pu nous connecter au serveur. Veuillez réessayer plus tard."
+      title: "Nous n'avons pas pu nous connecter au serveur"
     cant_view_mod:
       title: "Impossibilité de voir ce mod."
       extra:
@@ -426,9 +433,8 @@ fr:
       extra:
         failed_update_delete: "Échec de la suppression de fichiers pour la mise à jour. Annulation"
         failed_update_apply: "Échec d'application de la mise à jour. Annulation."
-        invalid_file_path: |
+        invalid_file_path: |-
           Le chemin du fichier est incorrect. Veuillez contacter les développeurs de Wheel Wizard.
-
           Erreur Serveur: {$1}
       title: "Annulation de la mise à jour de RR"
     restart_admin_fail:
@@ -454,9 +460,8 @@ fr:
       title: "Paramètres sauvegardés avec succès !"
     data_folder_moved:
       title: "Mise à jour du dossier de données"
-      extra: |
+      extra: |-
         Les données de Wheel Wizard sont désormais ici:
-
         {$1}
     rr_up_to_date:
       title: "Retro Rewind est bien à jour."
@@ -465,20 +470,20 @@ fr:
       title: "Converti en patchs"
     mod_installed:
       extra: "Le mod '{$1}' s'est installé avec succès."
-      title: "Installation du mod réussie!"
+      title: "Installation du mod réussie !"
     patch_conversion_result: "Conversion de {$1} fichier(s) en {$2} fichier(s) de patchs."
     patch_conversion_skipped: "{$1} fichier(s) laissé(s) tels quels car ils n'ont pas pu être convertis."
     patch_conversion_notes: "Note(s): {$1}"
   snackbar_warning:
-    cant_save_mii: "Impossible de savegarder le Mii"
+    cant_save_mii: "Impossible de sauvegarder le Mii"
     no_mii_export: "Il semblerait qu'il n'y ait aucun Mii à exporter"
     no_mii_delete: "Il semblerait qu'il n'y ait aucun Mii à supprimer"
   snackbar_success:
-    mii_added: "Le Mii a été ajouté a vos Miis"
+    mii_added: "Le Mii a été ajouté à vos Miis"
     copied_fc: "Code ami copié dans le presse-papier"
     name_change: "Changement du nom en '{$1}' avec succès"
     saved_mii: "Mii '{$1}' sauvegardé dans '{$2}'"
-    deleted: "Suppression de '{$1}' "
+    deleted: "Suppression de '{$1}'"
     deleted_miis: "Suppression de {$1} Miis"
     created_duplicate: "Copie de '{$1}'"
     created_duplicates_miis: "Copie de {$1} Miis"
@@ -518,10 +523,14 @@ fr:
     unsupported_loose_override_extension: "{$1} utilise une extension de remplacement loose non prise en charge (.kcl, .kmp, .slt)."
     whole_file_baseline: "Ce SZS est stocké comme base de références du fichier complet. Exportation d’un remplacement du fichier complet."
   option:
-    wh_wz_language: "Langue de Wheel Wizard"
+    wh_wz_language: "Langage de Wheel Wizard"
     force_disable_wiimote: "Forcer la désactivation des Wiimotes"
     launch_with_dolphin: "Lancer le jeu avec la fenêtre de Dolphin"
     launch_rr_on_startup: "Lancer Retro Rewind au démarrage"
+    retro_rewind_installation: "Installation de Retro Rewind"
+    save_folder: "Dossier des Sauvegardes"
+    installation_folder: "Dossier d'installation"
+    recomp_installation: "Installation de WiiCompiled"
     v_sync: "Synchronisation Verticale"
     recommended: "Paramètres Recommandés"
     show_fps: "Montrer les FPS"
@@ -529,69 +538,79 @@ fr:
     window_scale: "Taille de la fenêtre"
     open_config: "Ouvrir le dossier de configuration"
     wheel_wizard_data_folder: "Dossier de données Wheel Wizard"
+    retro_rewind_folder: "Dossier de Retro Rewind"
     reset_data_folder: "Utiliser le chemin par défaut"
     dolphin_user_path: "Dossier d'utilisateur Dolphin"
     mario_kart_game: "Fichier de Mario Kart Wii"
-    dolphin_emulator_exe: "Éxecutable Dolphin Emulator"
+    dolphin_emulator_exe: "Exécutable Dolphin Emulator"
     make_primary: "Définir par défaut"
-    remove_blur: "Retirer le flou"
     enable_animations: "Activer les animations"
-    reinstall: "Réinstaller Retro Rewind"
+    reinstall: "Réinstaller RR"
     open_game_folder: "Ouvrir le dossier du jeu"
     open_save_folder: "Ouvrir le dossier de sauvegarde"
     enable_recomp: "Activer WiiCompiled (bêta)"
-    recomp_use_dolphin_data: "Partager le dossier de sauvegarde de Dolphin"
+    recomp_share_dolphin_data: "Partager les données de NAND avec Dolphin"
+    recomp_clone_dolphin_data: "Copier la NAND de Dolphin"
     recomp_resolution: "Résolution"
     recomp_graphics_api: "API Graphique"
     recomp_prevent_stutters: "Empêcher les saccades"
   section:
-    language: "Langue"
+    graphics: "Graphismes"
+    general: "Général"
+    retro_rewind: "Retro Rewind"
+    language: "Langage"
     wii: "Paramètres Wii"
     resolution: "Résolution"
-    performance: "Paramètres de perfomance"
-    renderer: "Paramètres de rendu"
+    performance: "Paramètres de performance"
+    renderer: "Paramètres de Rendu"
     location_paths: "Paramètres de localisation"
     wh_wz_appearance: "Apparence de Wheel Wizard"
     installation: "Installation"
+    setup: "Installation"
     recomp: "WiiCompiled (bêta)"
-    recomp_dolphin_data: "Données de Dolphin"
     recomp_video: "Vidéo"
   helper_text:
     topbar:
       location_warning: "Les paramètres sont désactivés, finissez d'abord les paramètres de localisation"
     enable_recomp: "Utilise WiiCompiled comme lanceur. Désactivez pour utiliser Dolphin et Retro Rewind à la place. Windows uniquement."
-    recomp_use_dolphin_data: "Utilise le dossier Wii existant de Dolphin afin que WiiCompiled puisse partager les sauvegardes, Miis, et paramètres Wii. Les changements prennent effet au prochain lancement de WiiCompiled."
+    recomp_share_dolphin_data: "WiiCompiled et Dolphin utilisent les mêmes sauvegardes, Miis, et paramètres Wii."
+    recomp_shared_nand_warning: "N'exécutez pas Dolphin et WiiCompiled en même temps pendant le partage des données de NAND."
+    recomp_clone_dolphin_data: "Copie les sauvegardes, Miis, et paramètres Wii de Dolphin dans les données isolées de WiiCompiled."
     recomp_graphics_api: "Seuls DirectX 12 et Vulkan font tourner WiiCompiled fiablement, donc rien d'autre n'est proposé."
     recomp_dolphin_data_not_found: "Définissez un chemin vers le dossier utilisateur Dolphin dans les paramètres de localisation. Il doit contenir un dossier Wii."
-    recomp_prevent_stutters: "Lors de la compilation d'un shader, les objets qui ont en besoin sont ignorés pendant quelques frames au lieu de bloquer le jeu jusqu'a ce que la compilation soit terminée, provoquant un léger effet de \"pop-in\" au lieu d'un ralentissement"
+    recomp_prevent_stutters: "Lors de la compilation d'un shader, les objets qui en ont besoin sont ignorés pendant quelques frames au lieu de bloquer le jeu jusqu'à ce que la compilation soit terminée, provoquant un léger effet de \"pop-in\" au lieu d'un ralentissement"
     launch_with_dolphin: "Affichera la fenêtre d'accueil de Dolphin en plus de celle du jeu"
     launch_rr_on_startup: "Démarre automatiquement Retro Rewind quand Wheel Wizard se lance"
+    installed_version: "Version installée : {$1}"
     force_disable_wiimote: "Ce paramètre désactivera les Wiimotes en jeu, mais les activera dans le menu Wii"
     resolution_scale: "1x est la résolution native"
+    renderer: "Sélectionne le moteur de rendu que Dolphin utilise pour le rendu du jeu."
+    v_sync: "Synchronise la fréquence d'images par secondes (FPS) avec votre écran pour empêcher les déchirements d'écran."
     recommended: "Ce paramètre changera certains paramètres Dolphin pour réduire les saccades et les pics de lag"
     30_fps: "Ce paramètre forcera le jeu à tourner en 30 FPS (au lieu de 60)"
-    wheel_wizard_data_folder: "Choisissez là ou Wheel Wizard stocke ses fichiers. Le déplacement peut prendre un moment."
+    wheel_wizard_data_folder: "Choisissez là où Wheel Wizard stocke ses fichiers. Le déplacement peut prendre un moment."
+    retro_rewind_folder: "Ouvre le dossier qui contient les fichiers Retro Rewind installés."
     end_with_exe: "Le chemin doit se finir en .exe"
     enable_animations: "Cette option active les animations dans l'application Wheel Wizard"
     end_with_x: "Le chemin doit se finir avec:"
     wh_wz_language: "Cette option change uniquement la langue de Wheel Wizard. Pour changer la langue dans le jeu. Veuillez-le faire depuis les paramètres de Retro Rewind."
     optional: "Optionnel"
     must_set_paths: "Vous devez impérativement définir ces 3 chemins afin de jouer à Retro Rewind"
-    must_set_game_path: "Vous devez sélectionner votre fichier de jeu Mario Kart Wii avant de pouvoir jouer à Wiicompiled"
+    must_set_game_path: "Vous devez sélectionner votre fichier de jeu Mario Kart Wii avant de pouvoir jouer à WiiCompiled"
   category:
     dolphin: "Dolphin"
     about: "À propos"
     other: "Autre"
     general: "Général"
+    video: "Vidéo"
   status:
     recomp_dolphin_data_not_linked: "Non liées. WiiCompiled utilisera ses propres données Wii."
     recomp_dolphin_data_linked: "Partage des données de Dolphin depuis {$1}"
     recomp_dolphin_data_copied: "Utilisation d'une copie de vos données de Dolphin dans {$1}"
     recomp_dolphin_data_not_found: "Données de Dolphin introuvables"
-    recomp_not_installed: "WiiCompiled n'est pas encore installé. Installez le d'abord depuis l'accueil"
+    recomp_not_installed: "WiiCompiled n'est pas encore installé. Installez-le d'abord depuis l'accueil"
     recomp_uninstalled: "WiiCompiled a été désinstallé"
     data_folder:
-      default: "Utilisation du chemin par défaut."
       custom: "Utilisation d'un chemin personnalisé."
       moving: "Déplacement des données, veuillez patienter..."
   value:
@@ -611,5 +630,6 @@ fr:
       czech: "Tchèque"
       norwegian: "Norvégien"
       chinese: "Chinois"
+      polish: "Polonais"
       portuguese: "Portugais"
       z_translators: "Eppe, Yawshi, lenyet"

--- a/WheelWizard/Resources/Languages/fr.yml
+++ b/WheelWizard/Resources/Languages/fr.yml
@@ -257,6 +257,7 @@ fr:
     preparing_files_count: "Préparation de {$1} fichier(s)"
     installing_recomp: "Installation de WiiCompiled"
     updating_recomp: "Mise à jour WiiCompiled"
+    uninstalling_recomp: "Désinstallation de WiiCompiled"
     recomp_checking_release: "Recherche de la dernière version de WiiCompiled"
     recomp_downloading_setup: "Téléchargement de l'installateur de WiiCompiled"
     recomp_running_setup: "Exécution de l'installateur WiiCompiled"

--- a/WheelWizard/Resources/Languages/fr.yml
+++ b/WheelWizard/Resources/Languages/fr.yml
@@ -3,25 +3,28 @@ fr:
     home: "Accueil"
     settings: "Paramètres"
     mods: "My Stuff"
-    my_profiles: "Mes Licences"
+    patches: "Patchs"
+    my_profiles: "Mes Permis"
     rooms: "Salles"
     friends: "Amis"
-    room_details: "Détail de la salle"
+    leaderboard: "Leaderboard"
+    room_details: "Détails de la salle"
     my_miis: "Mes Miis"
   attribute:
     status_online: "En Ligne"
-    enabled: "Activer"
+    enabled: "Activé"
     title: "Titre"
-    status_offline: "Hors-Ligne"
+    all: "Tout"
+    status_offline: "Hors Ligne"
     name: "Nom"
     id: "ID"
     type: "Type"
     speed: "Vitesse"
     mod_name: "Nom du Mod"
-    average_room_vr: "Point Course en moyenne"
+    average_room_vr: "Moyenne des Points Course"
     losses: "Défaites"
-    wins: "Victoire"
-    races_played: "Course Jouées"
+    wins: "Victoires"
+    races_played: "Courses Jouées"
     friend_code: "Code Ami"
     player_count: "Joueurs"
     time_online: "Temps en ligne"
@@ -35,10 +38,10 @@ fr:
       size: "Taille"
       nose_type: "Type de nez"
       horizontal_position: "Position horizontale"
-      mouth_type: "Type de bouches"
+      mouth_type: "Type de bouche"
       hair_color: "Couleur des cheveux"
-      hair_type: "Type des cheveux"
-      mirror_hair: "Cheveux en miroir"
+      hair_type: "Type de cheveux"
+      mirror_hair: "Inverser cheveux"
       glasses_type: "Type de lunettes"
       glasses_color: "Couleur des lunettes"
       name: "Nom du Mii"
@@ -48,11 +51,11 @@ fr:
       fav_color: "Couleur favorite"
       skin_color: "Couleur de peau"
       head_shape: "Forme du visage"
-      facial_feature: "Élément facial"
+      facial_feature: "Traits du visage"
       irish_color: "Couleur des yeux"
-      space_between: "Espace entre deux éléments"
+      space_between: "Espacement"
       rotation: "Rotation (Gauche / Droite)"
-      eyebrow_type: "Type de cils"
+      eyebrow_type: "Type de sourcils"
       mustache_type: "Type de moustache"
       mustache_vertical_position: "Position verticale de la moustache"
       mustache_size: "Taille de la moustache"
@@ -62,26 +65,26 @@ fr:
     priority: "Priorité"
     sort_by: "Trier par"
     total_games_won: "Nombre de courses gagnées"
-    total_games_played: "Nombre de courses faites"
+    total_games_played: "Nombre de courses jouées"
     vr_abbreviation: "PTS.C"
     br_abbreviation: "PTS.B"
     br_full: "Points Bataille"
     vr_full: "Points Course"
     description: "Description"
     images: "Images"
-    likes: "J'aimes"
+    likes: "J'aime"
     views: "Vues"
     downloads: "Téléchargements"
     mii_section:
       general: "Général"
       face: "Tête"
       hair: "Cheveux"
-      eyebrows: "Cils"
-      eyes: "Oeil"
+      eyebrows: "Sourcils"
+      eyes: "Yeux"
       nose: "Nez"
       lips: "Lèvres"
       glasses: "Lunettes"
-      facial_hair: "Pillosité faciale"
+      facial_hair: "Pilosité faciale"
       mole: "Grain de beauté"
     gender: "Genre"
     gender_female: "Femme"
@@ -91,10 +94,10 @@ fr:
     installing: "Installation..."
     updating: "Mise à jour..."
     config_not_finished: "Configuration non terminée"
-    no_server: "Aucun Seveurs"
+    no_server: "Aucun Seveur"
     unknown: "Inconnu"
     error: "Erreur"
-    warning: "Avertisemment"
+    warning: "Avertissement"
     success: "Succès"
     extracting: "Extraction des fichers..."
     no_name: "Aucun nom"
@@ -104,12 +107,14 @@ fr:
     installed: "Installé"
   action:
     play: "Jouer"
-    play_offline: "Jouer en Hors-Ligne"
+    play_offline: "Jouer hors ligne"
+    play_anyway: "Jouer quand même"
     install: "Installer"
     update: "Mettre à Jour"
     import: "Importer"
-    enable_all: "Tous Activer"
-    disable_all: "Tous Désactiver"
+    convert_to_patches: "Convertir en Patchs"
+    enable_all: "Tout Activer"
+    disable_all: "Tout Désactiver"
     rename: "Renommer"
     delete: "Supprimer"
     open_folder: "Ouvrir le dossier"
@@ -122,11 +127,11 @@ fr:
     yes: "Oui"
     no: "Non"
     keep: "Garder"
-    ok: "Ok"
-    revert: "Revenir en arrière"
-    maybe_later: "Peut être plus tard"
+    ok: "OK"
+    revert: "Annuler"
+    maybe_later: "Peut-être plus tard"
     browse: "Chercher"
-    view_mod: "Détail du Mod"
+    view_mod: "Détails du Mod"
     save_external_mii: "Ajouter un Mii dans \"Mes Miis\""
     view_mii: "Voir le Mii"
     duplicate: "Dupliquer"
@@ -134,10 +139,13 @@ fr:
     unfavorite: "Retirer des favoris"
     favorite: "Favoris"
     view_room: "Voir la salle"
+    recomp_nand_copy: "Faire une copie"
+    recomp_nand_share: "Utiliser directement"
+    recomp_install_offline: "Installer en mode hors ligne"
     link:
-      discord: "Parlez-nous-en !"
-      github: "Code Source"
-      support: "Supportez-nous !"
+      discord: "Parlez-nous !"
+      github: "Code source"
+      support: "Soutenez-nous !"
     launch_dolphin: "Lancer Dolphin"
     randomize: "Aléatoire"
     do_manually: "Faire manuellement"
@@ -162,53 +170,60 @@ fr:
     miis: "Miis"
   popup_title:
     mod_details: "Détails du mod"
-    mod_browser: "Navigateur des mods"
+    mod_browser: "Navigateur de mods"
     mii_selector: "Sélection de Mii"
     mii_editor: "Éditeur de Mii"
-    mii_carousel: "Vue d'ensemble du Mii"
+    mii_carousel: "Vue d'ensemble des Miis"
   text:
-    made_by_string: |-
+    made_by_string: |
       Fait par: {$1}
       et {$2}
     thanks_translators: "Merci à tous les traducteurs:"
-    wh_wz_translation_percentage: "La traduction pour cette langue est fini à {$1}%"
-    powered_gamebanana: "Contribué par GameBanana"
+    wh_wz_translation_percentage: "La traduction pour cette langue est finie à {$1}%"
+    powered_gamebanana: "Propulsé par GameBanana"
     language_translated_by: "Cette langue a été traduite par: {$1}"
+    brsar_entry: "{$1} entrée {$2}"
+    brsar_entry_with_rwar: "{$1} entrée {$2} + RWAR"
+    external_reference: "Référence externe"
+    external_reference_with_path: "Référence externe: {$1}"
+    modified_archive_member: "Membre de l'archive modifié"
+    new_archive_member: "Nouveau membre de l'archive"
+    whole_file_override: "Écrasement du fichier entier"
   hover:
     players_online:
-      0: "Il n'y a actuellement aucun joueurs en ligne"
+      0: "Il n'y a actuellement aucun joueur en ligne"
       1: "Il y a actuellement 1 joueur en ligne"
       n: "Il y a actuellement {$1} joueurs en ligne"
     rooms_online:
-      0: "Il n'y a actuellement aucune salles active"
+      0: "Il n'y a actuellement aucune salle active"
       1: "Il y a actuellement 1 salle active"
       n: "Il y a actuellement {$1} salles active"
     friends_online:
-      0: "Il n'y a actuellement aucun amis en ligne"
+      0: "Il n'y a actuellement aucun ami en ligne"
       1: "Il y a actuellement 1 ami en ligne"
       n: "Il y a actuellement {$1} amis en ligne"
     rooms_page_disclaimer: |-
-      Attention, cete page ne propose pas la possibilité de rejoindre la salle directement.
-      Pour rejoindre une salle spécifique, vous devez soit la rejoindre via un ami ou espérer de la rejoindre via les serveur en ligne.
-    friends_page_disclaimer: "Ajouter des amis que vous voulez dans le jeu."
-    region_user_selection: "Ceci montre les régions que VOUS avez jouez"
+      Attention, cette page ne permet pas de rejoindre une salle directement.
+      Pour rejoindre une salle spécifique, vous devez soit la rejoindre via un ami, soit espérer la rejoindre via les serveurs en ligne.
+    friends_page_disclaimer: "Pour ajouter des amis rendez vous en jeu."
+    region_user_selection: "Ceci montre les régions dans lesquelles VOUS avez joué(e)"
     primary_profile: "Le profil principal est utilisé en tant que référence dans Wheel Wizard"
   empty_content:
-    no_profiles: "Vous devez avoir lancé le jeu au moins une fois pour voir vos profils listé ici"
+    no_profiles: "Vous devez lancer le jeu au moins une fois pour voir vos profils apparaître ici"
     no_friends_title: "Pas d'amis pour le moment !"
-    no_friends: "Vous pouvez ajouter vos amis in-game"
-    no_mods: "Les mods permettent de modifer comment le jeu va se comporter. Commencez à importer votre premier mod en cliquant sur le bouton en dessous."
+    no_friends: "Vous pouvez ajouter vos amis en jeu."
+    no_mods: "Les mods permettent de modifer le fonctionnement du jeu. Commencez à importer votre premier mod en cliquant sur le bouton en-dessous."
     no_mods_title: "Pas de mods trouvés"
-    no_rooms: "Vous n'avez pas de connexion internet ou personne n'est en train de jouer."
-    no_rooms_title: "Aucune salles trouvées"
+    no_rooms: "Soit vous n'avez pas de connexion à Internet, soit personne ne joue."
+    no_rooms_title: "Aucune salle trouvée"
     no_miis_title: "Aucun Mii!"
-    no_miis: "Nous ne pouvons pas lire les données du Mii de votre système. Veuillez vérifier que vous avez lancé le jeu au moins une fois"
+    no_miis: "Nous ne pouvons pas lire les données de Mii de votre système. Assurez-vous d'avoir lancé le jeu au moins une fois"
     no_mod_selected_title: "Aucun mod sélectionné"
-    no_mod_selected: "Sélectionner un mod dans la liste pour voir ces détails"
+    no_mod_selected: "Sélectionner un mod dans la liste pour voir ses détails"
   time:
     days:
-      1: "1 Jour"
-      n: "{$1} Jours"
+      1: "1 jour"
+      n: "{$1} jours"
     hours:
       1: "1 heure"
       n: "{$1} heures"
@@ -219,72 +234,124 @@ fr:
       1: "1 seconde"
       n: "{$1} secondes"
   progress:
-    estimated_time_remaining: "Temps restant estimé:"
-    downloading_mb: "Téléchargement de {$1} MB"
+    estimated_time_remaining: "Temps restant: "
+    downloading_mb: "téléchargement de {$1} MB"
     installing_mods: "Installation de mods"
     installing_mods_count: "Installation de {$1} mods"
     processing_xof_y: "Traitement de {$1} sur {$2} fichiers"
-    update_rr: "Mise à jour de Retro Rewind en cours..."
-    latest_wh_wz_github: "Obtenez la dernière version de Wheel Wizard depuis Github"
-    update_wh_wz: "Mise à jour de Wheel Wizard en cours..."
+    update_rr: "Mise à jour de Retro Rewind"
+    latest_wh_wz_github: "Obtention de la dernière version de Wheel Wizard depuis Github"
+    update_wh_wz: "Mise à jour de Wheel Wizard"
     installing_rr: "Installation de Retro Rewind"
     installing_rr_first_time: "Installation de Retro Rewind pour la première fois"
     installing_dolphin: "Installation de Dolphin Emulator"
+    updating_dolphin: "Mise à jour de Dolphin Emulator"
     this_may_take_a_while: "Cela peut prendre plus de temps en fonction de votre connexion internet."
+    applying_converted_mod: "Application du mod converti"
+    combining_files: "En train de combiner des fichiers"
+    converting_file: "Conversion de {$1}"
+    converting_files_count: "Conversion de {$1} fichier(s)"
+    converting_mod_to_patches: "Conversion du mod en patchs"
+    downloading_mod: "Téléchargement de {$1}"
+    installing_mod: "Installation du mod"
+    preparing_files_count: "Préparation de {$1} fichier(s)"
+    installing_recomp: "Installation de WiiCompiled"
+    updating_recomp: "Mise à jour WiiCompiled"
+    recomp_checking_release: "Recherche de la dernière version de WiiCompiled"
+    recomp_downloading_setup: "Téléchargement de l'installateur de WiiCompiled"
+    recomp_running_setup: "Exécution de l'installateur WiiCompiled"
+    recomp_finished: "WiiCompiled est prêt pour le lancement"
+    recomp_copying_nand: "Copie des données de Dolphin"
   question:
+    recomp_uninstall:
+      title: "Désinstaller WiiCompiled?"
+      extra_shared: "Cela supprime Wiicompiled. Vos sauvegardes resteront dans le dossier Wii de Dolphin, et Retro Rewind reste installé."
+      extra_private: "Cela supprime Wiicompiled, mais aussi les données de sauvegarde Wii, et Retro Rewind reste installé."
+      extra_copy: "Cela supprime Wiicompiled, mais aussi la copie de vos données Dolphin. Les données originales restent intactes, et Retro Rewind reste installé."
+    recomp_use_dolphin_nand:
+      title: "Utiliser vos données de sauvegarde Dolphin ?"
+      extra: "WiiCompiled peut démarrer avec les sauvegardes, Miis et codes ami que vous utilisiez déjà avec Dolphin. Sinon, il démarrera avec ses propres données vierges."
+    recomp_retro_wfc_unavailable:
+      title: "Impossible de communiquer avec Retro WFC"
+      extra: "WiiCompiled a besoin des serveurs Retro WFC pour préparer les services en ligne, mais ils ne répondent pas. Vous pouvez installer sans les fonctionnalités en ligne; et WiiCompiled les ajoutera automatiquement lors de la prochaine mise à jour, une fois les serveurs en ligne."
+    recomp_nand_mode:
+      title: "Copier les données de Dolphin, ou les utiliser directement?"
+      extra: "Dolphin ne recommande pas l'utilisation directe de ses données Wii (NAND), car l'écriture de données par deux programmes en simultané peut provoquer leur corruption. Une copie isolera complètement WiiCompiled, mais la progression effectuée dans l'une des copies ne sera pas dans l'autre."
     launch_clear_mods_found:
       title: "Mods trouvés"
-      extra: |-
-        Vous êtes sur le point de lancer le jeu sans aucun mods.
-        Voulez vous supprimer votre dossier My-Stuff ?
+      extra: "Vous êtes sur le point de lancer le jeu sans aucun mod. Voulez-vous supprimer le dossier My Stuff ?"
     sure_delete:
       title: "Êtes-vous sûr de vouloir supprimer {$1} ?"
-      extra: "La suppresion est permanente et ne peut pas être inversée."
+      extra: "La suppression est permanente et ne peut pas être annulée."
       title_miis: "Êtes-vous sûr de vouloir supprimer {$1} Miis ?"
     apply_scale:
-      title: "Voulez-vous appliquez la nouvelle échelle ?"
-      extra: "Cette modification va être rétablie dans {$1} sauf si vous choisissez de garder cette modification."
+      title: "Voulez-vous appliquer la nouvelle échelle ? "
+      extra: "Cette modification va être rétablie dans {$1} sauf si vous choisissez de la garder."
+    move_data:
+      title: "Déplacer les données de Wheel Wizard ?"
+      extra: |
+        Wheel Wizard déplacera ses fichiers vers:
+
+        {$1}
+
+        Cela peut prendre un moment selon la quantité de données.
     dolphin_found:
-      title: "Dossier Dolphin Emulator trouvé"
-      extra: |-
-        Si vous ne savez pas ce que tous cela veut dire, juste cliquez sur oui :)
-        Dossier Dolphin Emulator trouvé. Voulez-vous utilser ce dossier ?
+      title: "Dossier de l'émulateur Dolphin trouvé"
+      extra: |
+        Si vous ne savez pas ce que cela veut dire, cliquez juste sur oui :)
+
+        Dossier de l'émulateur Dolphin trouvé. Voulez-vous utilser ce dossier ?
+    dolphin_outdated:
+      title: "Votre émulateur Dolphin est obsolète"
+      extra: |
+        Cette version de Dolphin ({$1}) a une faille de sécurité connue qui permet aux fichiers de jeu, mods, ou tricheurs en ligne d'infecter votre PC avec des logiciels malveillants.
+
+        Mettez à jour vers la version {$2} ou ultérieure pour être sûr.
+    dolphin_program_found:
+      title: "Émulateur Dolphin trouvé"
+      extra: |
+        Si vous ne savez pas ce que cela veut dire, cliquez juste sur oui :)
+
+        Émulateur Dolphin trouvé. Voulez-vous l'utiliser ?
     new_version_wh_wz:
-      title: "Mise à jour Wheel Wizard disponible !"
-      extra: "La version {$1} de Wheel Wizard est disponible (Version actuelle: {$2}). Voulez-vous mettre à jour maintenant ?"
+      title: "Mise à jour de Wheel Wizard disponible !"
+      extra: "La version {$1} de Wheel Wizard est disponible (Version actuelle: {$2}). Voulez-vous mettre à jour maintenant ? "
     update_admin:
       title: "Mettre à jour en Administrateur"
-      extra: "Des fois, une mise à jour demande les droits d'admin. Voulez-vous les activer pour cette mise à jour ?"
+      extra: "Parfois, une mise à jour demande les droits d'admin. Voulez-vous les activer pour cette mise à jour ? "
     reinstall_rr:
-      title: "Réinstaller Retro Rewind"
+      title: "Réinstaller Retro Rewind "
       extra: "Êtes-vous sûr de vouloir réinstaller Retro Rewind ?"
     old_rksys_found:
-      title: "Ancien rksys.dat trouvé"
-      extra: "Une ancienne sauvegarde a été trouvée. Voulez-vous l'utiliser ? (Recommandé)"
+      title: "Ancien rksys.dat trouvé "
+      extra: "Une ancienne sauvegarde a été trouvée. Voulez-vous l'utiliser ? (Recommandé) "
     rr_to_old:
-      extra: |-
-        Votre version de Retro Rewind est trop vieille pour être mis à jour.
-        Voulez-vous réinstaller Retro Rewind ?
-      title: "Votre version de Retro Rewind est trop vieille."
+      extra: "Votre version de Retro Rewind est trop ancienne pour être mise à jour. Voulez-vous réinstaller Retro Rewind ?"
+      title: "Votre version de Retro Rewind est trop ancienne."
     rr_not_determined:
       title: "Télécharger Retro Rewind"
-      extra: |-
-        Votre version de Retro Rewind n'a pas pu être déterminée.
-        Voulez-vous installer Retro Rewind ?
+      extra: "Votre version de Retro Rewind n'a pas pu être déterminée. Voulez-vous installer Retro Rewind ?"
     dolphin_flatpak:
       title: "Installation de Dolphin Flatpak..."
-      extra: "La version Flatpak de Dolphin Emulator ne semble pas être installée. Veuillez-vous qu'on vous l'installe ?"
+      extra: "La version Flatpak de l'émulateur Dolphin ne semble pas être installée. Voulez-vous qu'on vous l'installe ? (pour cet utilisateur)"
     install_mod:
       title: "Voulez-vous télécharger et installer le mod suivant: {$1} ?"
     search_mod: "Recherche de mods..."
     enter_new_name:
       title: "Entrez un nouveau nom"
-      extra: "Changer le nom actuel à: {$1}"
+      extra: "Changer le nom de: {$1}"
+    enter_mod_name:
+      title: "Nom du mod:"
+    launch_clear_patches_found:
+      extra: "Vous êtes sur le point de lancer le jeu sans mod. Voulez-vous supprimer le dossier des patchs ? Si vous lancez quand même, le dossier des patchs actuel sera utilisé !"
+    apply_language_settings:
+      title: "Cela fermera la fenêtre actuelle et en ouvrira une nouvelle avec les nouveaux paramètres de langue."
+      extra: "Voulez-vous appliquer les nouveaux paramètres de langue ?"
   message_warning:
     not_find_dolphin:
-      extra: "N'a pas pu trouver Dolphin Emulator, veuillez choisir le chemin dans les paramètres"
+      extra: "Nous n'avons pas pu trouver l'émulateur Dolphin, veuillez définir le chemin dans les paramètres"
     not_find_game:
-      extra: "N'a pas pu trouver le jeu, veuillez chosir le chemin dans les paramètres"
+      extra: "Nous n'avons pas pu trouver le jeu, veuillez définir le chemin dans les paramètres"
     multiple_files_selected:
       title: "Plusieurs fichers sélectionnés"
     invalid_name:
@@ -295,31 +362,42 @@ fr:
       extra: "Vérifiez bien si tous les chemins sont corrects et essayez à nouveau."
       title: "Chemin invalide"
     dolphin_not_found:
-      title: "Dossier Dolphin Emulator non trouvé"
-      extra: "Le dossier Dolphin Emulator n'a pas été automatiquement trouvé. Veuillez essayé de trouver le dossier manuellement, cliquez sur \"Aide\" pour plus d'information."
+      title: "Dossier de l'émulateur Dolphin introuvable"
+      extra: "Le dossier de l'émulateur Dolphin n'a pas été automatiquement trouvé. Veuillez essayer de le trouver manuellement, cliquez sur \"Aide\" pour plus d'informations."
+    dolphin_version_unverified:
+      title: "Nous n'avons pas pu vérifier la version de votre émulateur Dolphin"
+      extra: |
+        Wheel Wizard n'a pas pu lire la version de l'émulateur Dolphin que vous avez installé, donc il ne peut pas déterminer si l'émulateur a les correctifs de sécurité.
+
+        Vérifiez que vous êtes sur la version {$1} ou ultérieure. Les anciennes versions ont une faille de sécurité connue qui permet aux fichiers de jeu, mods, ou tricheurs en ligne d'infecter votre PC avec des logiciels malveillants.
+    dolphin_tool_selected:
+      title: "Mauvais éxecutable Dolphin sélectionné"
+      extra: "Vous avez sélectionné DolphinTool.exe. Choisissez Dolphin.exe (l'éxecutable de l'émulateur Dolphin) à la place."
     fail_check_updates:
       title: "Échec de la vérification des mises à jour"
-      extra: "Impossibilité de vérifier les mises à jour actuellement. Vous n'êtes probablement pas connecté à internet ou le serveur est probablement en maintenance"
+      extra: "Impossibilité de vérifier les mises à jour actuellement. Soit vous n'êtes pas connecté à internet soit le serveur est peut-être en maintenance"
     unable_update_wh_wz:
       extra:
-        reason_network: |-
+        reason_network: |
           Impossible de vérifier si Wheel Wizard est mis à jour.
-          Vous pourrez expérimenter des problèmes d'internet.
-        reason_location: |-
-          Impossible de mettre à jour Wheel Wizard. Veuillez bien vérifier que l'application se trouve dans un dossier qui peut être écrit.
-          N'a pas pu trouver le dossier actuel.
+
+          Vous avez sûrement des problèmes de connexion.
+        reason_location: |
+          Impossible de mettre à jour Wheel Wizard. Veuillez bien vérifier que l'application se trouve dans un dossier dans lequel on peut écrire.
+
+          Nous n'avons pas pu trouver le dossier actuel.
       title: "Impossible de mettre à jour Wheel Wizard."
     no_connect_server:
-      extra: "N'a pas pu de se connecter au serveur. Veuillez réessayer plus tard."
-      title: "N'a pas pu se connecter au serveur"
+      extra: "Nous n'avons pas pu se connecter au serveur. Veuillez réessayer plus tard."
+      title: "Nous n'avons pu se connecter au serveur"
     cant_view_mod:
       title: "Impossibilité de voir ce mod."
       extra:
-        something_else: "Quelque chose a échoué en essayant d'ouvrir le mod choisi."
+        something_else: "Une erreur est survenue en essayant d'ouvrir le mod choisi."
         not_from_browser: "Impossibilité de voir un mod qui n'a pas été installé depuis GameBanana"
     cannot_delete_fav_mii:
       title: "Impossibilité de supprimer des Mii en favoris."
-      extra: "Un ou plusieurs des Miis choisis sont en favoris. Les Miis peuvent être supprimés seulement s'ils ne sont pas en favoris pour éviter une suppression involontaire."
+      extra: "Un ou plusieurs des Miis choisis sont en favoris. Les Miis peuvent être supprimés seulement s'ils ne sont pas en favoris pour éviter les suppressions involontaires."
     mod_name_invalid:
       title: "Nom du mod invalide."
       extra: "Le nom du mod contient des caractères invalides."
@@ -327,39 +405,44 @@ fr:
       title: "Le nom du mod ne peut pas être vide"
       extra: "Veuillez écrire un nom pour le mod."
     unable_download_mod:
-      title: "Impossibilité de télécharger le mod"
+      title: "Impossible de télécharger le mod"
       extra: "Les fichiers n'ont pas été trouvés."
+    could_not_convert_mod:
+      title: "Nous n'avons pas pu convertir le mod"
   placeholder:
     enter_mod_name: "Entrez le nom du mod..."
     search_mod: "Recherche de mods..."
-    enter_mii_name: "Entrez le nom du mii..."
-    enter_text_here: "Entrez un texte ici..."
+    enter_mii_name: "Entrez le nom du Mii..."
+    enter_text_here: "Entrez du texte ici..."
     search_for_players: "Recherche de joueurs..."
     enter_path: "Choisissez le chemin désiré ici..."
   message_error:
     no_mod_folder:
       extra: "Le dossier du mod n'existe pas"
+    data_folder_move:
+      title: "Échec du déplacement des données"
     abort_rr:
       extra:
-        failed_update_delete: "Échec de la désinstallation de fichiers pour la mise à jour. Annulation"
+        failed_update_delete: "Échec de la suppression de fichiers pour la mise à jour. Annulation"
         failed_update_apply: "Échec d'application de la mise à jour. Annulation."
-        invalid_file_path: |-
-          Chemin vers un fichier incorrect. Veuillez contacter les développeurs de Wheel Wizard.
-          Erreur Serveur:  {$1}
-      title: "Anuller la mise à jour de RR"
+        invalid_file_path: |
+          Le chemin du fichier est incorrect. Veuillez contacter les développeurs de Wheel Wizard.
+
+          Erreur Serveur: {$1}
+      title: "Annulation de la mise à jour de RR"
     restart_admin_fail:
       extra: "Échec du redémarrage avec les droits d'administrateur."
     generic_error:
       title: "Une erreur s'est produite."
     failed_create_mii_db:
-      title: "Échec de la création de la base de donnée des Miis"
+      title: "Échec de la création de la base de données des Miis"
     failed_change_name:
       title: "Échec du changement de nom"
     failed_change_mii:
       title: "Échec du changement de Mii"
     failed_install_dolphin:
       title: "Échec de l'installation de Dolphin"
-      extra: "L'installation de Dolphin Emulator a échoué. Veuillez essayer d'installer Flatpak Dolphin."
+      extra: "L'installation de l'émulateur Dolphin a échoué. Veuillez essayer d'installer Dolphin Flatpak."
     failed_retrieve_mod:
       title: "Échec d'obtention des informations du mod"
     mod_download_fail:
@@ -367,57 +450,100 @@ fr:
       extra: "Une erreur s'est produite pendant le téléchargement du mod suivant: {$1}"
   message_success:
     settings_saved:
-      title: "Paramètre sauvegarder avec succès !"
+      title: "Paramètres sauvegardés avec succès !"
+    data_folder_moved:
+      title: "Mise à jour du dossier de données"
+      extra: |
+        Les données de Wheel Wizard sont désormais ici:
+
+        {$1}
     rr_up_to_date:
       title: "Retro Rewind est bien à jour."
     mii_changed: "Changement du Mii avec succès"
+    mod_converted_to_patches:
+      title: "Converti en patchs"
+    mod_installed:
+      extra: "Le mod '{$1}' s'est installé avec succès."
+      title: "Installation du mod réussie!"
+    patch_conversion_result: "Conversion de {$1} fichier(s) en {$2} fichier(s) de patchs."
+    patch_conversion_skipped: "{$1} fichier(s) laissé(s) tels quels car ils n'ont pas pu être convertis."
+    patch_conversion_notes: "Note(s): {$1}"
   snackbar_warning:
     cant_save_mii: "Impossible de savegarder le Mii"
-    no_mii_export: "Il semblerait qu'aucun Miis peuvent être exporter"
-    no_mii_delete: "Il semblerait qu'aucun Miis peuvent être supprimer"
+    no_mii_export: "Il semblerait qu'il n'y ait aucun Mii à exporter"
+    no_mii_delete: "Il semblerait qu'il n'y ait aucun Mii à supprimer"
   snackbar_success:
     mii_added: "Le Mii a été ajouté a vos Miis"
-    copied_fc: "Code Ami copié dans le presse-papier"
+    copied_fc: "Code ami copié dans le presse-papier"
     name_change: "Changement du nom en '{$1}' avec succès"
-    saved_mii: "Mii '{$1}' sauvegardé au chemin suivant '{$2}'"
-    deleted: "Suppression de '{$1}'"
+    saved_mii: "Mii '{$1}' sauvegardé dans '{$2}'"
+    deleted: "Suppression de '{$1}' "
     deleted_miis: "Suppression de {$1} Miis"
-    created_duplicate: "Clonage de '{$1}'"
-    created_duplicates_miis: "Clonage de {$1} Miis"
-    profile_set_primary: "Choisir ce profil en profil principal"
+    created_duplicate: "Copie de '{$1}'"
+    created_duplicates_miis: "Copie de {$1} Miis"
+    profile_set_primary: "Profil défini en tant que profil principal"
+    dolphin_updated: "L'émulateur Dolphin a été mis à jour"
   snackbar_error:
     mii_failure_deserialize: "Échec de la désérialisation du Mii '{$1}'"
     mii_failure_update: "Échec de mise à jour du Mii '{$1}'"
-    mii_failure_save: "Échec de savegarde du Mii '{$1}'"
-    mii_failure_get: "Échec d'obtention du Mii '{$1}'"
+    mii_failure_save: "Échec de sauvegarde du Mii '{$1}'"
+    mii_failure_get: "Échec de l'obtention du Mii '{$1}'"
     mii_failure_serialize: "Échec de la sérialisation du Mii '{$1}'"
     mii_failure_create: "Échec de la création du Mii '{$1}'"
-    mii_failure_duplicate: "Échec du clonage des Miis '{$1}'"
+    mii_failure_duplicate: "Échec de la copie des Miis '{$1}'"
   helper_note:
     name_must_between: "Les noms doivent être composés de 3 à 10 caractères."
     creator_name_less11: "Le nom de l'auteur doit faire moins de 11 caractères."
     creator_name_less10: "Le nom de l'auteur doit faire moins de 10 caractères."
+  file_picker:
+    select_mod_file: "Sélectionnez le fichier de mod"
+  patch:
+    incompatible_mod:
+      message: "Ce mod est incompatible avec d'autres. Lancer en le gardant activé peut provoquer des crashs ou des comportements inattendus. Pensez à le convertir en patchs en faisant un clic droit sur le mod."
+      title: "MOD INCOMPATIBLE"
+  warning:
+    brsar_external_count: "{$1} Les entrées de fichier BRSAR sont des références externes et ne peuvent pas être exportées."
+    brsar_file_id_external: "Le fileID BRSAR {$1} est une référence externe de fichier et ne peut pas être exporté."
+    brsar_file_id_unsupported_magic: "Le fileID BRSAR {$1} a changé, mais il correspond à {$2} et Pulsar ne prend en charge que les remplacements \"en loose\" de fichiers RBNK/RSEQ/RWSD."
+    brsar_file_id_unresolved: "Le fileID BRSAR {$1} ne correspond à aucun fichier audio intégré pris en charge."
+    brsar_no_supported_differences: "Aucune différence RBNK/RSEQ/RWSD prise en charge n’a été trouvée par rapport à la base de références intégrée du jeu."
+    brsar_unresolved_count: "{$1} entrées de fichiers BRSAR intégrées n’ont pas pu être résolues avec certitude."
+    brsar_unsupported_summary: "Seules les entrées RBNK/RSEQ/RWSD peuvent être exportées. L’archive analysée contient également {$1}."
+    file_deletion_not_exportable: "{$1} existe uniquement dans l’archive d’origine. Les suppressions de fichiers ne peuvent pas être exportées sous forme de patchs \" en loose.\""
+    file_name_differs_from_archive_tag: "Le nom du fichier sélectionné diffère du tag de l'archive d’origine \"{$1}.szs\"."
+    file_not_in_built_in_baseline: "{$1} n’est pas présent dans la base de références intégrée du jeu."
+    no_szs_differences: "Aucune différence SZS n’a été trouvée par rapport à la base de références intégrée du jeu."
+    szs_matches_baseline: "Le SZS sélectionné correspond exactement à la base de références intégrée du jeu."
+    unsupported_loose_override_extension: "{$1} utilise une extension de remplacement loose non prise en charge (.kcl, .kmp, .slt)."
+    whole_file_baseline: "Ce SZS est stocké comme base de références du fichier complet. Exportation d’un remplacement du fichier complet."
   option:
     wh_wz_language: "Langue de Wheel Wizard"
     force_disable_wiimote: "Forcer la désactivation des Wiimotes"
-    launch_with_dolphin: "Lancer le jeu avec la fennêtre de Dolphin"
+    launch_with_dolphin: "Lancer le jeu avec la fenêtre de Dolphin"
+    launch_rr_on_startup: "Lancer Retro Rewind au démarrage"
     v_sync: "Synchronisation Verticale"
     recommended: "Paramètres Recommandés"
     show_fps: "Montrer les FPS"
-    renderer: "Rendu"
-    window_scale: "Taille de la fennêtre"
+    renderer: "Moteur de Rendu"
+    window_scale: "Taille de la fenêtre"
     open_config: "Ouvrir le dossier de configuration"
+    wheel_wizard_data_folder: "Dossier de données Wheel Wizard"
+    reset_data_folder: "Utiliser le chemin par défaut"
     dolphin_user_path: "Dossier d'utilisateur Dolphin"
-    mario_kart_game: "ISO Mario Kart Wii"
-    dolphin_emulator_exe: "Éxécutable Dolphin Emulator"
-    make_primary: "Défini par défaut"
+    mario_kart_game: "Fichier de Mario Kart Wii"
+    dolphin_emulator_exe: "Éxecutable Dolphin Emulator"
+    make_primary: "Définir par défaut"
+    remove_blur: "Retirer le flou"
     enable_animations: "Activer les animations"
     reinstall: "Réinstaller Retro Rewind"
     open_game_folder: "Ouvrir le dossier du jeu"
     open_save_folder: "Ouvrir le dossier de sauvegarde"
+    enable_recomp: "Activer WiiCompiled (bêta)"
+    recomp_use_dolphin_data: "Partager le dossier de sauvegarde de Dolphin"
+    recomp_resolution: "Résolution"
+    recomp_graphics_api: "API Graphique"
+    recomp_prevent_stutters: "Empêcher les saccades"
   section:
-    graphics: "Graphismes"
-    general: "Général"
     language: "Langue"
     wii: "Paramètres Wii"
     resolution: "Résolution"
@@ -426,24 +552,47 @@ fr:
     location_paths: "Paramètres de localisation"
     wh_wz_appearance: "Apparence de Wheel Wizard"
     installation: "Installation"
+    recomp: "WiiCompiled (bêta)"
+    recomp_dolphin_data: "Données de Dolphin"
+    recomp_video: "Vidéo"
   helper_text:
     topbar:
-      location_warning: "Les paramètres sont désactivés, complétez d'abord les paramètres de localisation"
-    launch_with_dolphin: "Ira lancer la fenêtre d'accueil de Dolphin en plus du jeu"
-    force_disable_wiimote: "Ce paramètre ira désactiver les Wiimotes dans le jeu, mais les activés dans le menu Wii"
+      location_warning: "Les paramètres sont désactivés, finissez d'abord les paramètres de localisation"
+    enable_recomp: "Utilise Wiicompiled comme launcher. Désactivez pour utiliser Dolphin et Retro Rewind à la place. Windows uniquement."
+    recomp_use_dolphin_data: "Utilise le dossier Wii existant de Dolphin afin que WiiCompiled puisse partager les sauvegardes, Miis, et paramètres Wii. Les changements prennent effet au prochain lancement de Wiicompiled."
+    recomp_graphics_api: "Seuls DirectX 12 et Vulkan font tourner WiiCompiled fiablement, donc rien d'autre n'est proposé."
+    recomp_dolphin_data_not_found: "Définissez un chemin vers le dossier utilisateur Dolphin dans les paramètres de localisation. Il doit contenir un dossier Wii."
+    recomp_prevent_stutters: "Lors de la compilation d'un shader, les objets qui ont en besoin sont ignorés pendant quelques frames au lieu de bloquer le jeu jusqu'a ce que la compilation soit terminée, provoquant un léger effet de \"pop-in\" au lieu d'un ralentissement"
+    launch_with_dolphin: "Affichera la fenêtre d'accueil de Dolphin en plus de celle du jeu"
+    launch_rr_on_startup: "Démarre automatiquement Retro Rewind quand Wheel Wizard se lance"
+    force_disable_wiimote: "Ce paramètre désactivera les Wiimotes en jeu, mais les activera dans le menu Wii"
     resolution_scale: "1x est la résolution native"
-    recommended: "Ce paramètre va changer certain paramètre Dolphin pour réduire les saccades et lag spikes"
-    30_fps: "Ce paramètre va forcer le jeu à tourner en 30 FPS (60 est par défaut)"
+    recommended: "Ce paramètre changera certains paramètres Dolphin pour réduire les saccades et les pics de lag"
+    30_fps: "Ce paramètre forcera le jeu à tourner en 30 FPS (au lieu de 60)"
+    wheel_wizard_data_folder: "Choisissez là ou Wheel Wizard stocke ses fichiers. Le déplacement peut prendre un moment."
     end_with_exe: "Le chemin doit se finir en .exe"
-    enable_animations: "Ceci active les animations dans l'application Wheel Wizard"
+    enable_animations: "Cette option active les animations dans l'application Wheel Wizard"
     end_with_x: "Le chemin doit se finir avec:"
+    wh_wz_language: "Cette option change uniquement la langue de Wheel Wizard. Pour changer la langue dans le jeu. Veuillez-le faire depuis les paramètres de Retro Rewind."
     optional: "Optionnel"
     must_set_paths: "Vous devez impérativement définir ces 3 chemins afin de jouer à Retro Rewind"
+    must_set_game_path: "Vous devez sélectionner votre fichier de jeu Mario Kart Wii avant de pouvoir jouer à Wiicompiled"
   category:
+    dolphin: "Dolphin"
     about: "À propos"
     other: "Autre"
     general: "Général"
-    video: "Vidéo"
+  status:
+    recomp_dolphin_data_not_linked: "Non liées. WiiCompiled utilisera ses propres données Wii."
+    recomp_dolphin_data_linked: "Partage des données de Dolphin depuis {$1}"
+    recomp_dolphin_data_copied: "Utilisation d'une copie de vos données de Dolphin dans {$1}"
+    recomp_dolphin_data_not_found: "Données de Dolphin introuvables"
+    recomp_not_installed: "WiiCompiled n'est pas encore installé. Installez le d'abord depuis l'accueil"
+    recomp_uninstalled: "WiiCompiled a été désinstallé"
+    data_folder:
+      default: "Utilisation du chemin par défaut."
+      custom: "Utilisation d'un chemin personnalisé."
+      moving: "Déplacement des données, veuillez patienter..."
   value:
     language:
       france: "Français"
@@ -462,4 +611,4 @@ fr:
       norwegian: "Norvégien"
       chinese: "Chinois"
       portuguese: "Portugais"
-      z_translators: "Eppe, Yawshi"
+      z_translators: "Eppe, Yawshi, lenyet"


### PR DESCRIPTION
## Purpose of this PR:
Made this PR to update the current french translation, as it's missing a lot of text (mainly from the WiiCompiled update I think)

###  How to Test:
I need one of the original translators or a french speaking person to proof read the new strings and my corrections as I did them all in one go, please let me know if I need to explain some of the changes I made

### What Has Been Changed:
Fixed a certain amount of spelling mistakes, translation errors and minor errors that were made in the current translation, and I added every string from en.yml that was missing in this file and I translated them, made it so both en.yml and this file have the same amount of lines and are translated using the same method so that future translations/updates hopefully become easier

### Related Issue Link:

None

## Checklist before merging
- [ ] You have created relevant tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated French translations for improved wording, spelling, grammar, capitalization, and terminology.
  * Added French text for patch management, conversion workflows, validation, warnings, errors, statuses, dialogs, and helper messages.
  * Expanded French export warnings for archive, BRSAR, and SZS patches.
  * Added translator attribution for lenyet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->